### PR TITLE
Add category list 

### DIFF
--- a/recordings/Categories-object_771091412/can-get-a-list-of-ancestor-categories_453326080/recording.har
+++ b/recordings/Categories-object_771091412/can-get-a-list-of-ancestor-categories_453326080/recording.har
@@ -1,0 +1,120 @@
+{
+  "log": {
+    "_recordingName": "Categories object/can get a list of ancestor categories",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "4.3.0"
+    },
+    "entries": [
+      {
+        "_id": "60aee74b579e72cceee26cfed8c254a8",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 677,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "677"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "localhost:8000"
+            }
+          ],
+          "headersSize": 254,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "[{\"operationName\":\"CategoryAncestorsList\",\"variables\":{\"first\":20,\"id\":\"Q2F0ZWdvcnk6MjI=\"},\"query\":\"fragment BaseCategory on Category {\\n  id\\n  name\\n  slug\\n  seoDescription\\n  seoTitle\\n  __typename\\n}\\n\\nfragment PageInfo on PageInfo {\\n  endCursor\\n  hasNextPage\\n  __typename\\n}\\n\\nquery CategoryAncestorsList($id: ID!, $first: Int!, $after: String) {\\n  category(id: $id) {\\n    id\\n    ancestors(first: $first, after: $after) {\\n      edges {\\n        node {\\n          ...BaseCategory\\n          __typename\\n        }\\n        __typename\\n      }\\n      pageInfo {\\n        ...PageInfo\\n        __typename\\n      }\\n      __typename\\n    }\\n    __typename\\n  }\\n}\\n\"}]"
+          },
+          "queryString": [],
+          "url": "http://localhost:8000/graphql/"
+        },
+        "response": {
+          "bodySize": 423,
+          "content": {
+            "mimeType": "application/json",
+            "size": 423,
+            "text": "[{\"data\": {\"category\": {\"id\": \"Q2F0ZWdvcnk6MjI=\", \"ancestors\": {\"edges\": [{\"node\": {\"id\": \"Q2F0ZWdvcnk6Nw==\", \"name\": \"Accessories\", \"slug\": \"accessories\", \"seoDescription\": \"\", \"seoTitle\": \"\", \"__typename\": \"Category\"}, \"__typename\": \"CategoryCountableEdge\"}], \"pageInfo\": {\"endCursor\": \"WyI3Il0=\", \"hasNextPage\": false, \"__typename\": \"PageInfo\"}, \"__typename\": \"CategoryCountableConnection\"}, \"__typename\": \"Category\"}}}]"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Fri, 07 Aug 2020 10:21:25 GMT"
+            },
+            {
+              "name": "server",
+              "value": "WSGIServer/0.2 CPython/3.8.1"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "423"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "referrer-policy",
+              "value": "same-origin"
+            }
+          ],
+          "headersSize": 193,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2020-08-07T10:21:25.017Z",
+        "time": 26,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 26
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/recordings/Categories-object_771091412/can-get-a-list-of-categories_789886841/recording.har
+++ b/recordings/Categories-object_771091412/can-get-a-list-of-categories_789886841/recording.har
@@ -1,0 +1,120 @@
+{
+  "log": {
+    "_recordingName": "Categories object/can get a list of categories",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "4.3.0"
+    },
+    "entries": [
+      {
+        "_id": "aa061eb7c4bda511f2741bbfbfb45b6a",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 546,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "546"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "localhost:8000"
+            }
+          ],
+          "headersSize": 254,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "[{\"operationName\":\"CategoryList\",\"variables\":{\"first\":20},\"query\":\"fragment BaseCategory on Category {\\n  id\\n  name\\n  slug\\n  seoDescription\\n  seoTitle\\n  __typename\\n}\\n\\nfragment PageInfo on PageInfo {\\n  endCursor\\n  hasNextPage\\n  __typename\\n}\\n\\nquery CategoryList($first: Int!, $after: String) {\\n  categories(first: $first, after: $after) {\\n    edges {\\n      node {\\n        ...BaseCategory\\n        __typename\\n      }\\n      __typename\\n    }\\n    pageInfo {\\n      ...PageInfo\\n      __typename\\n    }\\n    __typename\\n  }\\n}\\n\"}]"
+          },
+          "queryString": [],
+          "url": "http://localhost:8000/graphql/"
+        },
+        "response": {
+          "bodySize": 2164,
+          "content": {
+            "mimeType": "application/json",
+            "size": 2164,
+            "text": "[{\"data\": {\"categories\": {\"edges\": [{\"node\": {\"id\": \"Q2F0ZWdvcnk6Nw==\", \"name\": \"Accessories\", \"slug\": \"accessories\", \"seoDescription\": \"\", \"seoTitle\": \"\", \"__typename\": \"Category\"}, \"__typename\": \"CategoryCountableEdge\"}, {\"node\": {\"id\": \"Q2F0ZWdvcnk6OA==\", \"name\": \"Groceries\", \"slug\": \"groceries\", \"seoDescription\": \"\", \"seoTitle\": \"\", \"__typename\": \"Category\"}, \"__typename\": \"CategoryCountableEdge\"}, {\"node\": {\"id\": \"Q2F0ZWdvcnk6OQ==\", \"name\": \"Apparel\", \"slug\": \"apparel\", \"seoDescription\": \"\", \"seoTitle\": \"\", \"__typename\": \"Category\"}, \"__typename\": \"CategoryCountableEdge\"}, {\"node\": {\"id\": \"Q2F0ZWdvcnk6MTA=\", \"name\": \"T-shirts\", \"slug\": \"t-shirts\", \"seoDescription\": \"\", \"seoTitle\": \"\", \"__typename\": \"Category\"}, \"__typename\": \"CategoryCountableEdge\"}, {\"node\": {\"id\": \"Q2F0ZWdvcnk6MTE=\", \"name\": \"Polo Shirts\", \"slug\": \"polo-shirts\", \"seoDescription\": \"\", \"seoTitle\": \"\", \"__typename\": \"Category\"}, \"__typename\": \"CategoryCountableEdge\"}, {\"node\": {\"id\": \"Q2F0ZWdvcnk6MTI=\", \"name\": \"Hoodies\", \"slug\": \"hoodies\", \"seoDescription\": \"\", \"seoTitle\": \"\", \"__typename\": \"Category\"}, \"__typename\": \"CategoryCountableEdge\"}, {\"node\": {\"id\": \"Q2F0ZWdvcnk6MTM=\", \"name\": \"Footwear\", \"slug\": \"footwear\", \"seoDescription\": \"\", \"seoTitle\": \"\", \"__typename\": \"Category\"}, \"__typename\": \"CategoryCountableEdge\"}, {\"node\": {\"id\": \"Q2F0ZWdvcnk6MTQ=\", \"name\": \"Juices\", \"slug\": \"juices\", \"seoDescription\": \"\", \"seoTitle\": \"\", \"__typename\": \"Category\"}, \"__typename\": \"CategoryCountableEdge\"}, {\"node\": {\"id\": \"Q2F0ZWdvcnk6MTU=\", \"name\": \"Alcohol\", \"slug\": \"alcohol\", \"seoDescription\": \"\", \"seoTitle\": \"\", \"__typename\": \"Category\"}, \"__typename\": \"CategoryCountableEdge\"}, {\"node\": {\"id\": \"Q2F0ZWdvcnk6MjA=\", \"name\": \"Paints\", \"slug\": \"paints\", \"seoDescription\": \"\", \"seoTitle\": \"\", \"__typename\": \"Category\"}, \"__typename\": \"CategoryCountableEdge\"}, {\"node\": {\"id\": \"Q2F0ZWdvcnk6MjI=\", \"name\": \"Homewares\", \"slug\": \"homewares\", \"seoDescription\": \"\", \"seoTitle\": \"\", \"__typename\": \"Category\"}, \"__typename\": \"CategoryCountableEdge\"}], \"pageInfo\": {\"endCursor\": \"WyIyMiJd\", \"hasNextPage\": false, \"__typename\": \"PageInfo\"}, \"__typename\": \"CategoryCountableConnection\"}}}]"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Fri, 07 Aug 2020 10:07:50 GMT"
+            },
+            {
+              "name": "server",
+              "value": "WSGIServer/0.2 CPython/3.8.1"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "2164"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "referrer-policy",
+              "value": "same-origin"
+            }
+          ],
+          "headersSize": 194,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2020-08-07T10:07:50.507Z",
+        "time": 34,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 34
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/recordings/Categories-object_771091412/can-get-a-list-of-subcategories_1450129737/recording.har
+++ b/recordings/Categories-object_771091412/can-get-a-list-of-subcategories_1450129737/recording.har
@@ -1,0 +1,120 @@
+{
+  "log": {
+    "_recordingName": "Categories object/can get a list of subcategories",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "4.3.0"
+    },
+    "entries": [
+      {
+        "_id": "aaf0908a161bb108b9c661258b830063",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 674,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "674"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "localhost:8000"
+            }
+          ],
+          "headersSize": 254,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "[{\"operationName\":\"CategoryChildrenList\",\"variables\":{\"first\":20,\"id\":\"Q2F0ZWdvcnk6Nw==\"},\"query\":\"fragment BaseCategory on Category {\\n  id\\n  name\\n  slug\\n  seoDescription\\n  seoTitle\\n  __typename\\n}\\n\\nfragment PageInfo on PageInfo {\\n  endCursor\\n  hasNextPage\\n  __typename\\n}\\n\\nquery CategoryChildrenList($id: ID!, $first: Int!, $after: String) {\\n  category(id: $id) {\\n    id\\n    children(first: $first, after: $after) {\\n      edges {\\n        node {\\n          ...BaseCategory\\n          __typename\\n        }\\n        __typename\\n      }\\n      pageInfo {\\n        ...PageInfo\\n        __typename\\n      }\\n      __typename\\n    }\\n    __typename\\n  }\\n}\\n\"}]"
+          },
+          "queryString": [],
+          "url": "http://localhost:8000/graphql/"
+        },
+        "response": {
+          "bodySize": 595,
+          "content": {
+            "mimeType": "application/json",
+            "size": 595,
+            "text": "[{\"data\": {\"category\": {\"id\": \"Q2F0ZWdvcnk6Nw==\", \"children\": {\"edges\": [{\"node\": {\"id\": \"Q2F0ZWdvcnk6MjA=\", \"name\": \"Paints\", \"slug\": \"paints\", \"seoDescription\": \"\", \"seoTitle\": \"\", \"__typename\": \"Category\"}, \"__typename\": \"CategoryCountableEdge\"}, {\"node\": {\"id\": \"Q2F0ZWdvcnk6MjI=\", \"name\": \"Homewares\", \"slug\": \"homewares\", \"seoDescription\": \"\", \"seoTitle\": \"\", \"__typename\": \"Category\"}, \"__typename\": \"CategoryCountableEdge\"}], \"pageInfo\": {\"endCursor\": \"WyIyMiJd\", \"hasNextPage\": false, \"__typename\": \"PageInfo\"}, \"__typename\": \"CategoryCountableConnection\"}, \"__typename\": \"Category\"}}}]"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Fri, 07 Aug 2020 10:21:33 GMT"
+            },
+            {
+              "name": "server",
+              "value": "WSGIServer/0.2 CPython/3.8.1"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "595"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "referrer-policy",
+              "value": "same-origin"
+            }
+          ],
+          "headersSize": 193,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2020-08-07T10:21:33.138Z",
+        "time": 31,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 31
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/recordings/Categories-object_771091412/can-get-new-page_168101874/recording.har
+++ b/recordings/Categories-object_771091412/can-get-new-page_168101874/recording.har
@@ -1,6 +1,6 @@
 {
   "log": {
-    "_recordingName": "Collection object/can get new page",
+    "_recordingName": "Categories object/can get new page",
     "creator": {
       "comment": "persister:fs",
       "name": "Polly.JS",
@@ -8,11 +8,11 @@
     },
     "entries": [
       {
-        "_id": "0aec0301c834a93399cca032886d92e7",
+        "_id": "f5dcb6d9a2028649256f03fb9ba5b8d8",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 655,
+          "bodySize": 545,
           "cookies": [],
           "headers": [
             {
@@ -28,7 +28,7 @@
             {
               "_fromType": "array",
               "name": "content-length",
-              "value": "655"
+              "value": "545"
             },
             {
               "_fromType": "array",
@@ -56,23 +56,23 @@
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "[{\"operationName\":\"CollectionList\",\"variables\":{\"first\":1},\"query\":\"fragment BaseCollection on Collection {\\n  id\\n  name\\n  slug\\n  seoDescription\\n  seoTitle\\n  __typename\\n}\\n\\nfragment PageInfo on PageInfo {\\n  endCursor\\n  hasNextPage\\n  __typename\\n}\\n\\nquery CollectionList($first: Int!, $after: String, $sortBy: CollectionSortingInput, $filter: CollectionFilterInput) {\\n  collections(first: $first, after: $after, sortBy: $sortBy, filter: $filter) {\\n    edges {\\n      node {\\n        ...BaseCollection\\n        __typename\\n      }\\n      __typename\\n    }\\n    pageInfo {\\n      ...PageInfo\\n      __typename\\n    }\\n    __typename\\n  }\\n}\\n\"}]"
+            "text": "[{\"operationName\":\"CategoryList\",\"variables\":{\"first\":1},\"query\":\"fragment BaseCategory on Category {\\n  id\\n  name\\n  slug\\n  seoDescription\\n  seoTitle\\n  __typename\\n}\\n\\nfragment PageInfo on PageInfo {\\n  endCursor\\n  hasNextPage\\n  __typename\\n}\\n\\nquery CategoryList($first: Int!, $after: String) {\\n  categories(first: $first, after: $after) {\\n    edges {\\n      node {\\n        ...BaseCategory\\n        __typename\\n      }\\n      __typename\\n    }\\n    pageInfo {\\n      ...PageInfo\\n      __typename\\n    }\\n    __typename\\n  }\\n}\\n\"}]"
           },
           "queryString": [],
           "url": "http://localhost:8000/graphql/"
         },
         "response": {
-          "bodySize": 400,
+          "bodySize": 357,
           "content": {
             "mimeType": "application/json",
-            "size": 400,
-            "text": "[{\"data\": {\"collections\": {\"edges\": [{\"node\": {\"id\": \"Q29sbGVjdGlvbjox\", \"name\": \"Summer collection\", \"slug\": \"summer-collection\", \"seoDescription\": null, \"seoTitle\": null, \"__typename\": \"Collection\"}, \"__typename\": \"CollectionCountableEdge\"}], \"pageInfo\": {\"endCursor\": \"WyJzdW1tZXItY29sbGVjdGlvbiJd\", \"hasNextPage\": true, \"__typename\": \"PageInfo\"}, \"__typename\": \"CollectionCountableConnection\"}}}]"
+            "size": 357,
+            "text": "[{\"data\": {\"categories\": {\"edges\": [{\"node\": {\"id\": \"Q2F0ZWdvcnk6Nw==\", \"name\": \"Accessories\", \"slug\": \"accessories\", \"seoDescription\": \"\", \"seoTitle\": \"\", \"__typename\": \"Category\"}, \"__typename\": \"CategoryCountableEdge\"}], \"pageInfo\": {\"endCursor\": \"WyI3Il0=\", \"hasNextPage\": true, \"__typename\": \"PageInfo\"}, \"__typename\": \"CategoryCountableConnection\"}}}]"
           },
           "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Fri, 07 Aug 2020 11:47:25 GMT"
+              "value": "Fri, 07 Aug 2020 10:07:50 GMT"
             },
             {
               "name": "server",
@@ -84,7 +84,7 @@
             },
             {
               "name": "content-length",
-              "value": "400"
+              "value": "357"
             },
             {
               "name": "x-content-type-options",
@@ -101,8 +101,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2020-08-07T11:47:25.230Z",
-        "time": 24,
+        "startedDateTime": "2020-08-07T10:07:50.573Z",
+        "time": 22,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -110,15 +110,15 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 24
+          "wait": 22
         }
       },
       {
-        "_id": "772f95d78b40b0c04d7538ebea15c47e",
+        "_id": "5fe846df41619f986d2857acedaf7871",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 694,
+          "bodySize": 564,
           "cookies": [],
           "headers": [
             {
@@ -134,7 +134,7 @@
             {
               "_fromType": "array",
               "name": "content-length",
-              "value": "694"
+              "value": "564"
             },
             {
               "_fromType": "array",
@@ -162,17 +162,17 @@
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "[{\"operationName\":\"CollectionList\",\"variables\":{\"first\":1,\"after\":\"WyJzdW1tZXItY29sbGVjdGlvbiJd\"},\"query\":\"fragment BaseCollection on Collection {\\n  id\\n  name\\n  slug\\n  seoDescription\\n  seoTitle\\n  __typename\\n}\\n\\nfragment PageInfo on PageInfo {\\n  endCursor\\n  hasNextPage\\n  __typename\\n}\\n\\nquery CollectionList($first: Int!, $after: String) {\\n  collections(first: $first, after: $after) {\\n    edges {\\n      node {\\n        ...BaseCollection\\n        __typename\\n      }\\n      __typename\\n    }\\n    pageInfo {\\n      ...PageInfo\\n      __typename\\n    }\\n    __typename\\n  }\\n}\\n\"}]"
+            "text": "[{\"operationName\":\"CategoryList\",\"variables\":{\"first\":1,\"after\":\"WyI3Il0=\"},\"query\":\"fragment BaseCategory on Category {\\n  id\\n  name\\n  slug\\n  seoDescription\\n  seoTitle\\n  __typename\\n}\\n\\nfragment PageInfo on PageInfo {\\n  endCursor\\n  hasNextPage\\n  __typename\\n}\\n\\nquery CategoryList($first: Int!, $after: String) {\\n  categories(first: $first, after: $after) {\\n    edges {\\n      node {\\n        ...BaseCategory\\n        __typename\\n      }\\n      __typename\\n    }\\n    pageInfo {\\n      ...PageInfo\\n      __typename\\n    }\\n    __typename\\n  }\\n}\\n\"}]"
           },
           "queryString": [],
           "url": "http://localhost:8000/graphql/"
         },
         "response": {
-          "bodySize": 381,
+          "bodySize": 353,
           "content": {
             "mimeType": "application/json",
-            "size": 381,
-            "text": "[{\"data\": {\"collections\": {\"edges\": [{\"node\": {\"id\": \"Q29sbGVjdGlvbjoy\", \"name\": \"Winter sale\", \"slug\": \"winter-sale\", \"seoDescription\": null, \"seoTitle\": null, \"__typename\": \"Collection\"}, \"__typename\": \"CollectionCountableEdge\"}], \"pageInfo\": {\"endCursor\": \"WyJ3aW50ZXItc2FsZSJd\", \"hasNextPage\": false, \"__typename\": \"PageInfo\"}, \"__typename\": \"CollectionCountableConnection\"}}}]"
+            "size": 353,
+            "text": "[{\"data\": {\"categories\": {\"edges\": [{\"node\": {\"id\": \"Q2F0ZWdvcnk6OA==\", \"name\": \"Groceries\", \"slug\": \"groceries\", \"seoDescription\": \"\", \"seoTitle\": \"\", \"__typename\": \"Category\"}, \"__typename\": \"CategoryCountableEdge\"}], \"pageInfo\": {\"endCursor\": \"WyI4Il0=\", \"hasNextPage\": true, \"__typename\": \"PageInfo\"}, \"__typename\": \"CategoryCountableConnection\"}}}]"
           },
           "cookies": [],
           "headers": [
@@ -190,7 +190,7 @@
             },
             {
               "name": "content-length",
-              "value": "381"
+              "value": "353"
             },
             {
               "name": "x-content-type-options",
@@ -207,8 +207,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2020-08-07T10:14:04.024Z",
-        "time": 33,
+        "startedDateTime": "2020-08-07T10:14:04.151Z",
+        "time": 35,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -216,7 +216,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 33
+          "wait": 35
         }
       }
     ],

--- a/recordings/Collection-object_874587352/can-get-new-page_168101874/recording.har
+++ b/recordings/Collection-object_874587352/can-get-new-page_168101874/recording.har
@@ -114,7 +114,7 @@
         }
       },
       {
-        "_id": "772f95d78b40b0c04d7538ebea15c47e",
+        "_id": "66d870cceda1594f6da7a4bc2f64689c",
         "_order": 0,
         "cache": {},
         "request": {
@@ -162,7 +162,7 @@
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "[{\"operationName\":\"CollectionList\",\"variables\":{\"first\":1,\"after\":\"WyJzdW1tZXItY29sbGVjdGlvbiJd\"},\"query\":\"fragment BaseCollection on Collection {\\n  id\\n  name\\n  slug\\n  seoDescription\\n  seoTitle\\n  __typename\\n}\\n\\nfragment PageInfo on PageInfo {\\n  endCursor\\n  hasNextPage\\n  __typename\\n}\\n\\nquery CollectionList($first: Int!, $after: String) {\\n  collections(first: $first, after: $after) {\\n    edges {\\n      node {\\n        ...BaseCollection\\n        __typename\\n      }\\n      __typename\\n    }\\n    pageInfo {\\n      ...PageInfo\\n      __typename\\n    }\\n    __typename\\n  }\\n}\\n\"}]"
+            "text": "[{\"operationName\":\"CollectionList\",\"variables\":{\"first\":1,\"after\":\"WyJzdW1tZXItY29sbGVjdGlvbiJd\"},\"query\":\"fragment BaseCollection on Collection {\\n  id\\n  name\\n  slug\\n  seoDescription\\n  seoTitle\\n  __typename\\n}\\n\\nfragment PageInfo on PageInfo {\\n  endCursor\\n  hasNextPage\\n  __typename\\n}\\n\\nquery CollectionList($first: Int!, $after: String, $sortBy: CollectionSortingInput, $filter: CollectionFilterInput) {\\n  collections(first: $first, after: $after, sortBy: $sortBy, filter: $filter) {\\n    edges {\\n      node {\\n        ...BaseCollection\\n        __typename\\n      }\\n      __typename\\n    }\\n    pageInfo {\\n      ...PageInfo\\n      __typename\\n    }\\n    __typename\\n  }\\n}\\n\"}]"
           },
           "queryString": [],
           "url": "http://localhost:8000/graphql/"
@@ -178,7 +178,7 @@
           "headers": [
             {
               "name": "date",
-              "value": "Fri, 07 Aug 2020 10:14:04 GMT"
+              "value": "Fri, 07 Aug 2020 12:09:07 GMT"
             },
             {
               "name": "server",
@@ -207,8 +207,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2020-08-07T10:14:04.024Z",
-        "time": 33,
+        "startedDateTime": "2020-08-07T12:09:07.330Z",
+        "time": 32,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -216,7 +216,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 33
+          "wait": 32
         }
       }
     ],

--- a/recordings/useCategoryAncestorsList_2888345230/can-fetch-category-ancestors_938056385/recording.har
+++ b/recordings/useCategoryAncestorsList_2888345230/can-fetch-category-ancestors_938056385/recording.har
@@ -1,0 +1,120 @@
+{
+  "log": {
+    "_recordingName": "useCategoryAncestorsList/can fetch category ancestors",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "4.3.0"
+    },
+    "entries": [
+      {
+        "_id": "60aee74b579e72cceee26cfed8c254a8",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 677,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "677"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "localhost:8000"
+            }
+          ],
+          "headersSize": 254,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "[{\"operationName\":\"CategoryAncestorsList\",\"variables\":{\"first\":20,\"id\":\"Q2F0ZWdvcnk6MjI=\"},\"query\":\"fragment BaseCategory on Category {\\n  id\\n  name\\n  slug\\n  seoDescription\\n  seoTitle\\n  __typename\\n}\\n\\nfragment PageInfo on PageInfo {\\n  endCursor\\n  hasNextPage\\n  __typename\\n}\\n\\nquery CategoryAncestorsList($id: ID!, $first: Int!, $after: String) {\\n  category(id: $id) {\\n    id\\n    ancestors(first: $first, after: $after) {\\n      edges {\\n        node {\\n          ...BaseCategory\\n          __typename\\n        }\\n        __typename\\n      }\\n      pageInfo {\\n        ...PageInfo\\n        __typename\\n      }\\n      __typename\\n    }\\n    __typename\\n  }\\n}\\n\"}]"
+          },
+          "queryString": [],
+          "url": "http://localhost:8000/graphql/"
+        },
+        "response": {
+          "bodySize": 423,
+          "content": {
+            "mimeType": "application/json",
+            "size": 423,
+            "text": "[{\"data\": {\"category\": {\"id\": \"Q2F0ZWdvcnk6MjI=\", \"ancestors\": {\"edges\": [{\"node\": {\"id\": \"Q2F0ZWdvcnk6Nw==\", \"name\": \"Accessories\", \"slug\": \"accessories\", \"seoDescription\": \"\", \"seoTitle\": \"\", \"__typename\": \"Category\"}, \"__typename\": \"CategoryCountableEdge\"}], \"pageInfo\": {\"endCursor\": \"WyI3Il0=\", \"hasNextPage\": false, \"__typename\": \"PageInfo\"}, \"__typename\": \"CategoryCountableConnection\"}, \"__typename\": \"Category\"}}}]"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Fri, 07 Aug 2020 11:31:00 GMT"
+            },
+            {
+              "name": "server",
+              "value": "WSGIServer/0.2 CPython/3.8.1"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "423"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "referrer-policy",
+              "value": "same-origin"
+            }
+          ],
+          "headersSize": 193,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2020-08-07T11:31:00.787Z",
+        "time": 26,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 26
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/recordings/useCategoryAncestorsList_2888345230/can-fetch-next-page_318554557/recording.har
+++ b/recordings/useCategoryAncestorsList_2888345230/can-fetch-next-page_318554557/recording.har
@@ -1,0 +1,120 @@
+{
+  "log": {
+    "_recordingName": "useCategoryAncestorsList/can fetch next page",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "4.3.0"
+    },
+    "entries": [
+      {
+        "_id": "88b934bb6f0ed433c32197fb5f433d34",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 676,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "676"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "localhost:8000"
+            }
+          ],
+          "headersSize": 254,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "[{\"operationName\":\"CategoryAncestorsList\",\"variables\":{\"first\":1,\"id\":\"Q2F0ZWdvcnk6MjI=\"},\"query\":\"fragment BaseCategory on Category {\\n  id\\n  name\\n  slug\\n  seoDescription\\n  seoTitle\\n  __typename\\n}\\n\\nfragment PageInfo on PageInfo {\\n  endCursor\\n  hasNextPage\\n  __typename\\n}\\n\\nquery CategoryAncestorsList($id: ID!, $first: Int!, $after: String) {\\n  category(id: $id) {\\n    id\\n    ancestors(first: $first, after: $after) {\\n      edges {\\n        node {\\n          ...BaseCategory\\n          __typename\\n        }\\n        __typename\\n      }\\n      pageInfo {\\n        ...PageInfo\\n        __typename\\n      }\\n      __typename\\n    }\\n    __typename\\n  }\\n}\\n\"}]"
+          },
+          "queryString": [],
+          "url": "http://localhost:8000/graphql/"
+        },
+        "response": {
+          "bodySize": 423,
+          "content": {
+            "mimeType": "application/json",
+            "size": 423,
+            "text": "[{\"data\": {\"category\": {\"id\": \"Q2F0ZWdvcnk6MjI=\", \"ancestors\": {\"edges\": [{\"node\": {\"id\": \"Q2F0ZWdvcnk6Nw==\", \"name\": \"Accessories\", \"slug\": \"accessories\", \"seoDescription\": \"\", \"seoTitle\": \"\", \"__typename\": \"Category\"}, \"__typename\": \"CategoryCountableEdge\"}], \"pageInfo\": {\"endCursor\": \"WyI3Il0=\", \"hasNextPage\": false, \"__typename\": \"PageInfo\"}, \"__typename\": \"CategoryCountableConnection\"}, \"__typename\": \"Category\"}}}]"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Fri, 07 Aug 2020 11:31:00 GMT"
+            },
+            {
+              "name": "server",
+              "value": "WSGIServer/0.2 CPython/3.8.1"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "423"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "referrer-policy",
+              "value": "same-origin"
+            }
+          ],
+          "headersSize": 193,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2020-08-07T11:31:00.835Z",
+        "time": 19,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 19
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/recordings/useCategoryChildrenList_1320879699/can-fetch-next-page_318554557/recording.har
+++ b/recordings/useCategoryChildrenList_1320879699/can-fetch-next-page_318554557/recording.har
@@ -1,0 +1,226 @@
+{
+  "log": {
+    "_recordingName": "useCategoryChildrenList/can fetch next page",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "4.3.0"
+    },
+    "entries": [
+      {
+        "_id": "96f90e5788bc549fd7b9963a1f5311fc",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 673,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "673"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "localhost:8000"
+            }
+          ],
+          "headersSize": 254,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "[{\"operationName\":\"CategoryChildrenList\",\"variables\":{\"first\":1,\"id\":\"Q2F0ZWdvcnk6Nw==\"},\"query\":\"fragment BaseCategory on Category {\\n  id\\n  name\\n  slug\\n  seoDescription\\n  seoTitle\\n  __typename\\n}\\n\\nfragment PageInfo on PageInfo {\\n  endCursor\\n  hasNextPage\\n  __typename\\n}\\n\\nquery CategoryChildrenList($id: ID!, $first: Int!, $after: String) {\\n  category(id: $id) {\\n    id\\n    children(first: $first, after: $after) {\\n      edges {\\n        node {\\n          ...BaseCategory\\n          __typename\\n        }\\n        __typename\\n      }\\n      pageInfo {\\n        ...PageInfo\\n        __typename\\n      }\\n      __typename\\n    }\\n    __typename\\n  }\\n}\\n\"}]"
+          },
+          "queryString": [],
+          "url": "http://localhost:8000/graphql/"
+        },
+        "response": {
+          "bodySize": 411,
+          "content": {
+            "mimeType": "application/json",
+            "size": 411,
+            "text": "[{\"data\": {\"category\": {\"id\": \"Q2F0ZWdvcnk6Nw==\", \"children\": {\"edges\": [{\"node\": {\"id\": \"Q2F0ZWdvcnk6MjA=\", \"name\": \"Paints\", \"slug\": \"paints\", \"seoDescription\": \"\", \"seoTitle\": \"\", \"__typename\": \"Category\"}, \"__typename\": \"CategoryCountableEdge\"}], \"pageInfo\": {\"endCursor\": \"WyIyMCJd\", \"hasNextPage\": true, \"__typename\": \"PageInfo\"}, \"__typename\": \"CategoryCountableConnection\"}, \"__typename\": \"Category\"}}}]"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Fri, 07 Aug 2020 11:31:00 GMT"
+            },
+            {
+              "name": "server",
+              "value": "WSGIServer/0.2 CPython/3.8.1"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "411"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "referrer-policy",
+              "value": "same-origin"
+            }
+          ],
+          "headersSize": 193,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2020-08-07T11:31:00.912Z",
+        "time": 22,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 22
+        }
+      },
+      {
+        "_id": "92ea0ba2bfd0ba0604adb50f2da753a6",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 692,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "692"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "localhost:8000"
+            }
+          ],
+          "headersSize": 254,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "[{\"operationName\":\"CategoryChildrenList\",\"variables\":{\"first\":1,\"id\":\"Q2F0ZWdvcnk6Nw==\",\"after\":\"WyIyMCJd\"},\"query\":\"fragment BaseCategory on Category {\\n  id\\n  name\\n  slug\\n  seoDescription\\n  seoTitle\\n  __typename\\n}\\n\\nfragment PageInfo on PageInfo {\\n  endCursor\\n  hasNextPage\\n  __typename\\n}\\n\\nquery CategoryChildrenList($id: ID!, $first: Int!, $after: String) {\\n  category(id: $id) {\\n    id\\n    children(first: $first, after: $after) {\\n      edges {\\n        node {\\n          ...BaseCategory\\n          __typename\\n        }\\n        __typename\\n      }\\n      pageInfo {\\n        ...PageInfo\\n        __typename\\n      }\\n      __typename\\n    }\\n    __typename\\n  }\\n}\\n\"}]"
+          },
+          "queryString": [],
+          "url": "http://localhost:8000/graphql/"
+        },
+        "response": {
+          "bodySize": 418,
+          "content": {
+            "mimeType": "application/json",
+            "size": 418,
+            "text": "[{\"data\": {\"category\": {\"id\": \"Q2F0ZWdvcnk6Nw==\", \"children\": {\"edges\": [{\"node\": {\"id\": \"Q2F0ZWdvcnk6MjI=\", \"name\": \"Homewares\", \"slug\": \"homewares\", \"seoDescription\": \"\", \"seoTitle\": \"\", \"__typename\": \"Category\"}, \"__typename\": \"CategoryCountableEdge\"}], \"pageInfo\": {\"endCursor\": \"WyIyMiJd\", \"hasNextPage\": false, \"__typename\": \"PageInfo\"}, \"__typename\": \"CategoryCountableConnection\"}, \"__typename\": \"Category\"}}}]"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Fri, 07 Aug 2020 11:31:00 GMT"
+            },
+            {
+              "name": "server",
+              "value": "WSGIServer/0.2 CPython/3.8.1"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "418"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "referrer-policy",
+              "value": "same-origin"
+            }
+          ],
+          "headersSize": 193,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2020-08-07T11:31:00.949Z",
+        "time": 22,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 22
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/recordings/useCategoryChildrenList_1320879699/can-fetch-subcategories_203972675/recording.har
+++ b/recordings/useCategoryChildrenList_1320879699/can-fetch-subcategories_203972675/recording.har
@@ -1,0 +1,120 @@
+{
+  "log": {
+    "_recordingName": "useCategoryChildrenList/can fetch subcategories",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "4.3.0"
+    },
+    "entries": [
+      {
+        "_id": "aaf0908a161bb108b9c661258b830063",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 674,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "674"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "localhost:8000"
+            }
+          ],
+          "headersSize": 254,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "[{\"operationName\":\"CategoryChildrenList\",\"variables\":{\"first\":20,\"id\":\"Q2F0ZWdvcnk6Nw==\"},\"query\":\"fragment BaseCategory on Category {\\n  id\\n  name\\n  slug\\n  seoDescription\\n  seoTitle\\n  __typename\\n}\\n\\nfragment PageInfo on PageInfo {\\n  endCursor\\n  hasNextPage\\n  __typename\\n}\\n\\nquery CategoryChildrenList($id: ID!, $first: Int!, $after: String) {\\n  category(id: $id) {\\n    id\\n    children(first: $first, after: $after) {\\n      edges {\\n        node {\\n          ...BaseCategory\\n          __typename\\n        }\\n        __typename\\n      }\\n      pageInfo {\\n        ...PageInfo\\n        __typename\\n      }\\n      __typename\\n    }\\n    __typename\\n  }\\n}\\n\"}]"
+          },
+          "queryString": [],
+          "url": "http://localhost:8000/graphql/"
+        },
+        "response": {
+          "bodySize": 595,
+          "content": {
+            "mimeType": "application/json",
+            "size": 595,
+            "text": "[{\"data\": {\"category\": {\"id\": \"Q2F0ZWdvcnk6Nw==\", \"children\": {\"edges\": [{\"node\": {\"id\": \"Q2F0ZWdvcnk6MjA=\", \"name\": \"Paints\", \"slug\": \"paints\", \"seoDescription\": \"\", \"seoTitle\": \"\", \"__typename\": \"Category\"}, \"__typename\": \"CategoryCountableEdge\"}, {\"node\": {\"id\": \"Q2F0ZWdvcnk6MjI=\", \"name\": \"Homewares\", \"slug\": \"homewares\", \"seoDescription\": \"\", \"seoTitle\": \"\", \"__typename\": \"Category\"}, \"__typename\": \"CategoryCountableEdge\"}], \"pageInfo\": {\"endCursor\": \"WyIyMiJd\", \"hasNextPage\": false, \"__typename\": \"PageInfo\"}, \"__typename\": \"CategoryCountableConnection\"}, \"__typename\": \"Category\"}}}]"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Fri, 07 Aug 2020 11:31:00 GMT"
+            },
+            {
+              "name": "server",
+              "value": "WSGIServer/0.2 CPython/3.8.1"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "595"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "referrer-policy",
+              "value": "same-origin"
+            }
+          ],
+          "headersSize": 193,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2020-08-07T11:31:00.874Z",
+        "time": 21,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 21
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/recordings/useCategoryList_3293125748/can-fetch-categories_3152617879/recording.har
+++ b/recordings/useCategoryList_3293125748/can-fetch-categories_3152617879/recording.har
@@ -1,0 +1,120 @@
+{
+  "log": {
+    "_recordingName": "useCategoryList/can fetch categories",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "4.3.0"
+    },
+    "entries": [
+      {
+        "_id": "aa061eb7c4bda511f2741bbfbfb45b6a",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 546,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "546"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "localhost:8000"
+            }
+          ],
+          "headersSize": 254,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "[{\"operationName\":\"CategoryList\",\"variables\":{\"first\":20},\"query\":\"fragment BaseCategory on Category {\\n  id\\n  name\\n  slug\\n  seoDescription\\n  seoTitle\\n  __typename\\n}\\n\\nfragment PageInfo on PageInfo {\\n  endCursor\\n  hasNextPage\\n  __typename\\n}\\n\\nquery CategoryList($first: Int!, $after: String) {\\n  categories(first: $first, after: $after) {\\n    edges {\\n      node {\\n        ...BaseCategory\\n        __typename\\n      }\\n      __typename\\n    }\\n    pageInfo {\\n      ...PageInfo\\n      __typename\\n    }\\n    __typename\\n  }\\n}\\n\"}]"
+          },
+          "queryString": [],
+          "url": "http://localhost:8000/graphql/"
+        },
+        "response": {
+          "bodySize": 2164,
+          "content": {
+            "mimeType": "application/json",
+            "size": 2164,
+            "text": "[{\"data\": {\"categories\": {\"edges\": [{\"node\": {\"id\": \"Q2F0ZWdvcnk6Nw==\", \"name\": \"Accessories\", \"slug\": \"accessories\", \"seoDescription\": \"\", \"seoTitle\": \"\", \"__typename\": \"Category\"}, \"__typename\": \"CategoryCountableEdge\"}, {\"node\": {\"id\": \"Q2F0ZWdvcnk6OA==\", \"name\": \"Groceries\", \"slug\": \"groceries\", \"seoDescription\": \"\", \"seoTitle\": \"\", \"__typename\": \"Category\"}, \"__typename\": \"CategoryCountableEdge\"}, {\"node\": {\"id\": \"Q2F0ZWdvcnk6OQ==\", \"name\": \"Apparel\", \"slug\": \"apparel\", \"seoDescription\": \"\", \"seoTitle\": \"\", \"__typename\": \"Category\"}, \"__typename\": \"CategoryCountableEdge\"}, {\"node\": {\"id\": \"Q2F0ZWdvcnk6MTA=\", \"name\": \"T-shirts\", \"slug\": \"t-shirts\", \"seoDescription\": \"\", \"seoTitle\": \"\", \"__typename\": \"Category\"}, \"__typename\": \"CategoryCountableEdge\"}, {\"node\": {\"id\": \"Q2F0ZWdvcnk6MTE=\", \"name\": \"Polo Shirts\", \"slug\": \"polo-shirts\", \"seoDescription\": \"\", \"seoTitle\": \"\", \"__typename\": \"Category\"}, \"__typename\": \"CategoryCountableEdge\"}, {\"node\": {\"id\": \"Q2F0ZWdvcnk6MTI=\", \"name\": \"Hoodies\", \"slug\": \"hoodies\", \"seoDescription\": \"\", \"seoTitle\": \"\", \"__typename\": \"Category\"}, \"__typename\": \"CategoryCountableEdge\"}, {\"node\": {\"id\": \"Q2F0ZWdvcnk6MTM=\", \"name\": \"Footwear\", \"slug\": \"footwear\", \"seoDescription\": \"\", \"seoTitle\": \"\", \"__typename\": \"Category\"}, \"__typename\": \"CategoryCountableEdge\"}, {\"node\": {\"id\": \"Q2F0ZWdvcnk6MTQ=\", \"name\": \"Juices\", \"slug\": \"juices\", \"seoDescription\": \"\", \"seoTitle\": \"\", \"__typename\": \"Category\"}, \"__typename\": \"CategoryCountableEdge\"}, {\"node\": {\"id\": \"Q2F0ZWdvcnk6MTU=\", \"name\": \"Alcohol\", \"slug\": \"alcohol\", \"seoDescription\": \"\", \"seoTitle\": \"\", \"__typename\": \"Category\"}, \"__typename\": \"CategoryCountableEdge\"}, {\"node\": {\"id\": \"Q2F0ZWdvcnk6MjA=\", \"name\": \"Paints\", \"slug\": \"paints\", \"seoDescription\": \"\", \"seoTitle\": \"\", \"__typename\": \"Category\"}, \"__typename\": \"CategoryCountableEdge\"}, {\"node\": {\"id\": \"Q2F0ZWdvcnk6MjI=\", \"name\": \"Homewares\", \"slug\": \"homewares\", \"seoDescription\": \"\", \"seoTitle\": \"\", \"__typename\": \"Category\"}, \"__typename\": \"CategoryCountableEdge\"}], \"pageInfo\": {\"endCursor\": \"WyIyMiJd\", \"hasNextPage\": false, \"__typename\": \"PageInfo\"}, \"__typename\": \"CategoryCountableConnection\"}}}]"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Fri, 07 Aug 2020 11:14:28 GMT"
+            },
+            {
+              "name": "server",
+              "value": "WSGIServer/0.2 CPython/3.8.1"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "2164"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "referrer-policy",
+              "value": "same-origin"
+            }
+          ],
+          "headersSize": 194,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2020-08-07T11:14:28.433Z",
+        "time": 36,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 36
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/recordings/useCategoryList_3293125748/can-fetch-next-page_318554557/recording.har
+++ b/recordings/useCategoryList_3293125748/can-fetch-next-page_318554557/recording.har
@@ -1,0 +1,226 @@
+{
+  "log": {
+    "_recordingName": "useCategoryList/can fetch next page",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "4.3.0"
+    },
+    "entries": [
+      {
+        "_id": "f5dcb6d9a2028649256f03fb9ba5b8d8",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 545,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "545"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "localhost:8000"
+            }
+          ],
+          "headersSize": 254,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "[{\"operationName\":\"CategoryList\",\"variables\":{\"first\":1},\"query\":\"fragment BaseCategory on Category {\\n  id\\n  name\\n  slug\\n  seoDescription\\n  seoTitle\\n  __typename\\n}\\n\\nfragment PageInfo on PageInfo {\\n  endCursor\\n  hasNextPage\\n  __typename\\n}\\n\\nquery CategoryList($first: Int!, $after: String) {\\n  categories(first: $first, after: $after) {\\n    edges {\\n      node {\\n        ...BaseCategory\\n        __typename\\n      }\\n      __typename\\n    }\\n    pageInfo {\\n      ...PageInfo\\n      __typename\\n    }\\n    __typename\\n  }\\n}\\n\"}]"
+          },
+          "queryString": [],
+          "url": "http://localhost:8000/graphql/"
+        },
+        "response": {
+          "bodySize": 357,
+          "content": {
+            "mimeType": "application/json",
+            "size": 357,
+            "text": "[{\"data\": {\"categories\": {\"edges\": [{\"node\": {\"id\": \"Q2F0ZWdvcnk6Nw==\", \"name\": \"Accessories\", \"slug\": \"accessories\", \"seoDescription\": \"\", \"seoTitle\": \"\", \"__typename\": \"Category\"}, \"__typename\": \"CategoryCountableEdge\"}], \"pageInfo\": {\"endCursor\": \"WyI3Il0=\", \"hasNextPage\": true, \"__typename\": \"PageInfo\"}, \"__typename\": \"CategoryCountableConnection\"}}}]"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Fri, 07 Aug 2020 11:14:28 GMT"
+            },
+            {
+              "name": "server",
+              "value": "WSGIServer/0.2 CPython/3.8.1"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "357"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "referrer-policy",
+              "value": "same-origin"
+            }
+          ],
+          "headersSize": 193,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2020-08-07T11:14:28.503Z",
+        "time": 20,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 20
+        }
+      },
+      {
+        "_id": "5fe846df41619f986d2857acedaf7871",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 564,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "564"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "localhost:8000"
+            }
+          ],
+          "headersSize": 254,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "[{\"operationName\":\"CategoryList\",\"variables\":{\"first\":1,\"after\":\"WyI3Il0=\"},\"query\":\"fragment BaseCategory on Category {\\n  id\\n  name\\n  slug\\n  seoDescription\\n  seoTitle\\n  __typename\\n}\\n\\nfragment PageInfo on PageInfo {\\n  endCursor\\n  hasNextPage\\n  __typename\\n}\\n\\nquery CategoryList($first: Int!, $after: String) {\\n  categories(first: $first, after: $after) {\\n    edges {\\n      node {\\n        ...BaseCategory\\n        __typename\\n      }\\n      __typename\\n    }\\n    pageInfo {\\n      ...PageInfo\\n      __typename\\n    }\\n    __typename\\n  }\\n}\\n\"}]"
+          },
+          "queryString": [],
+          "url": "http://localhost:8000/graphql/"
+        },
+        "response": {
+          "bodySize": 353,
+          "content": {
+            "mimeType": "application/json",
+            "size": 353,
+            "text": "[{\"data\": {\"categories\": {\"edges\": [{\"node\": {\"id\": \"Q2F0ZWdvcnk6OA==\", \"name\": \"Groceries\", \"slug\": \"groceries\", \"seoDescription\": \"\", \"seoTitle\": \"\", \"__typename\": \"Category\"}, \"__typename\": \"CategoryCountableEdge\"}], \"pageInfo\": {\"endCursor\": \"WyI4Il0=\", \"hasNextPage\": true, \"__typename\": \"PageInfo\"}, \"__typename\": \"CategoryCountableConnection\"}}}]"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Fri, 07 Aug 2020 11:14:28 GMT"
+            },
+            {
+              "name": "server",
+              "value": "WSGIServer/0.2 CPython/3.8.1"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "353"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "referrer-policy",
+              "value": "same-origin"
+            }
+          ],
+          "headersSize": 193,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2020-08-07T11:14:28.539Z",
+        "time": 24,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 24
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/recordings/useCollection_1335116312/can-fetch-next-page_318554557/recording.har
+++ b/recordings/useCollection_1335116312/can-fetch-next-page_318554557/recording.har
@@ -126,7 +126,7 @@
         }
       },
       {
-        "_id": "f92aaff170d3f1d870ad06edb51e4535",
+        "_id": "772f95d78b40b0c04d7538ebea15c47e",
         "_order": 0,
         "cache": {},
         "request": {
@@ -174,7 +174,7 @@
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "[{\"operationName\":\"CollectionList\",\"variables\":{\"after\":\"WyJzdW1tZXItY29sbGVjdGlvbiJd\",\"first\":1},\"query\":\"fragment BaseCollection on Collection {\\n  id\\n  name\\n  slug\\n  seoDescription\\n  seoTitle\\n  __typename\\n}\\n\\nfragment PageInfo on PageInfo {\\n  endCursor\\n  hasNextPage\\n  __typename\\n}\\n\\nquery CollectionList($first: Int!, $after: String) {\\n  collections(first: $first, after: $after) {\\n    edges {\\n      node {\\n        ...BaseCollection\\n        __typename\\n      }\\n      __typename\\n    }\\n    pageInfo {\\n      ...PageInfo\\n      __typename\\n    }\\n    __typename\\n  }\\n}\\n\"}]"
+            "text": "[{\"operationName\":\"CollectionList\",\"variables\":{\"first\":1,\"after\":\"WyJzdW1tZXItY29sbGVjdGlvbiJd\"},\"query\":\"fragment BaseCollection on Collection {\\n  id\\n  name\\n  slug\\n  seoDescription\\n  seoTitle\\n  __typename\\n}\\n\\nfragment PageInfo on PageInfo {\\n  endCursor\\n  hasNextPage\\n  __typename\\n}\\n\\nquery CollectionList($first: Int!, $after: String) {\\n  collections(first: $first, after: $after) {\\n    edges {\\n      node {\\n        ...BaseCollection\\n        __typename\\n      }\\n      __typename\\n    }\\n    pageInfo {\\n      ...PageInfo\\n      __typename\\n    }\\n    __typename\\n  }\\n}\\n\"}]"
           },
           "queryString": [],
           "url": "http://localhost:8000/graphql/"
@@ -190,7 +190,7 @@
           "headers": [
             {
               "name": "date",
-              "value": "Thu, 06 Aug 2020 15:01:59 GMT"
+              "value": "Fri, 07 Aug 2020 10:14:04 GMT"
             },
             {
               "name": "server",
@@ -201,38 +201,26 @@
               "value": "application/json"
             },
             {
-              "name": "access-control-allow-origin",
-              "value": "http://localhost:3001"
-            },
-            {
-              "name": "access-control-allow-methods",
-              "value": "POST, OPTIONS"
-            },
-            {
-              "name": "access-control-allow-headers",
-              "value": "Origin, Content-Type, Accept, Authorization"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
               "name": "content-length",
               "value": "381"
             },
             {
               "name": "x-content-type-options",
               "value": "nosniff"
+            },
+            {
+              "name": "referrer-policy",
+              "value": "same-origin"
             }
           ],
-          "headersSize": 375,
+          "headersSize": 193,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2020-08-06T15:01:59.239Z",
-        "time": 19,
+        "startedDateTime": "2020-08-07T10:14:04.093Z",
+        "time": 30,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -240,7 +228,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 19
+          "wait": 30
         }
       }
     ],

--- a/src/api/categories/CategoryAncestorsList.ts
+++ b/src/api/categories/CategoryAncestorsList.ts
@@ -1,0 +1,28 @@
+import BaseList, { GetPageInfo, MapQueryData } from "../../helpers/BaseList";
+import {
+  CategoryAncestorsList as CategoryAncestorsListQuery,
+  CategoryAncestorsListVariables,
+} from "../../queries/gqlTypes/CategoryAncestorsList";
+import { BaseCategory } from "../../fragments/gqlTypes/BaseCategory";
+import { categoryAncestorsList } from "../../queries/category";
+
+export class CategoryAncestorsList extends BaseList<
+  CategoryAncestorsListQuery,
+  BaseCategory,
+  CategoryAncestorsListVariables
+> {
+  getPageInfo: GetPageInfo<CategoryAncestorsListQuery> = result =>
+    result.data.category?.ancestors?.pageInfo!;
+
+  mapQueryData: MapQueryData<CategoryAncestorsListQuery, BaseCategory> = data =>
+    data.category?.ancestors?.edges.map(({ node }) => node);
+
+  query = (variables: CategoryAncestorsListVariables) =>
+    this.client!.query<
+      CategoryAncestorsListQuery,
+      CategoryAncestorsListVariables
+    >({
+      query: categoryAncestorsList,
+      variables,
+    });
+}

--- a/src/api/categories/CategoryChildrenList.ts
+++ b/src/api/categories/CategoryChildrenList.ts
@@ -1,0 +1,28 @@
+import BaseList, { GetPageInfo, MapQueryData } from "../../helpers/BaseList";
+import {
+  CategoryChildrenList as CategoryChildrenListQuery,
+  CategoryChildrenListVariables,
+} from "../../queries/gqlTypes/CategoryChildrenList";
+import { BaseCategory } from "../../fragments/gqlTypes/BaseCategory";
+import { categoryChildrenList } from "../../queries/category";
+
+export class CategoryChildrenList extends BaseList<
+  CategoryChildrenListQuery,
+  BaseCategory,
+  CategoryChildrenListVariables
+> {
+  getPageInfo: GetPageInfo<CategoryChildrenListQuery> = result =>
+    result.data.category?.children?.pageInfo!;
+
+  mapQueryData: MapQueryData<CategoryChildrenListQuery, BaseCategory> = data =>
+    data.category?.children?.edges.map(({ node }) => node);
+
+  query = (variables: CategoryChildrenListVariables) =>
+    this.client!.query<
+      CategoryChildrenListQuery,
+      CategoryChildrenListVariables
+    >({
+      query: categoryChildrenList,
+      variables,
+    });
+}

--- a/src/api/categories/CategoryList.ts
+++ b/src/api/categories/CategoryList.ts
@@ -1,0 +1,25 @@
+import BaseList, { GetPageInfo, MapQueryData } from "../../helpers/BaseList";
+import {
+  CategoryList as CategoryListQuery,
+  CategoryListVariables,
+} from "../../queries/gqlTypes/CategoryList";
+import { BaseCategory } from "../../fragments/gqlTypes/BaseCategory";
+import { categoryList } from "../../queries/category";
+
+export class CategoryList extends BaseList<
+  CategoryListQuery,
+  BaseCategory,
+  CategoryListVariables
+> {
+  getPageInfo: GetPageInfo<CategoryListQuery> = result =>
+    result.data.categories?.pageInfo!;
+
+  mapQueryData: MapQueryData<CategoryListQuery, BaseCategory> = data =>
+    data.categories?.edges.map(({ node }) => node);
+
+  query = (variables: CategoryListVariables) =>
+    this.client!.query<CategoryListQuery, CategoryListVariables>({
+      query: categoryList,
+      variables,
+    });
+}

--- a/src/api/categories/__snapshots__/categories.test.ts.snap
+++ b/src/api/categories/__snapshots__/categories.test.ts.snap
@@ -1,0 +1,162 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Categories object can get a list of ancestor categories 1`] = `
+Array [
+  Object {
+    "__typename": "Category",
+    "id": "Q2F0ZWdvcnk6Nw==",
+    "name": "Accessories",
+    "seoDescription": "",
+    "seoTitle": "",
+    "slug": "accessories",
+  },
+]
+`;
+
+exports[`Categories object can get a list of categories 1`] = `
+Array [
+  Object {
+    "__typename": "Category",
+    "id": "Q2F0ZWdvcnk6Nw==",
+    "name": "Accessories",
+    "seoDescription": "",
+    "seoTitle": "",
+    "slug": "accessories",
+  },
+  Object {
+    "__typename": "Category",
+    "id": "Q2F0ZWdvcnk6OA==",
+    "name": "Groceries",
+    "seoDescription": "",
+    "seoTitle": "",
+    "slug": "groceries",
+  },
+  Object {
+    "__typename": "Category",
+    "id": "Q2F0ZWdvcnk6OQ==",
+    "name": "Apparel",
+    "seoDescription": "",
+    "seoTitle": "",
+    "slug": "apparel",
+  },
+  Object {
+    "__typename": "Category",
+    "id": "Q2F0ZWdvcnk6MTA=",
+    "name": "T-shirts",
+    "seoDescription": "",
+    "seoTitle": "",
+    "slug": "t-shirts",
+  },
+  Object {
+    "__typename": "Category",
+    "id": "Q2F0ZWdvcnk6MTE=",
+    "name": "Polo Shirts",
+    "seoDescription": "",
+    "seoTitle": "",
+    "slug": "polo-shirts",
+  },
+  Object {
+    "__typename": "Category",
+    "id": "Q2F0ZWdvcnk6MTI=",
+    "name": "Hoodies",
+    "seoDescription": "",
+    "seoTitle": "",
+    "slug": "hoodies",
+  },
+  Object {
+    "__typename": "Category",
+    "id": "Q2F0ZWdvcnk6MTM=",
+    "name": "Footwear",
+    "seoDescription": "",
+    "seoTitle": "",
+    "slug": "footwear",
+  },
+  Object {
+    "__typename": "Category",
+    "id": "Q2F0ZWdvcnk6MTQ=",
+    "name": "Juices",
+    "seoDescription": "",
+    "seoTitle": "",
+    "slug": "juices",
+  },
+  Object {
+    "__typename": "Category",
+    "id": "Q2F0ZWdvcnk6MTU=",
+    "name": "Alcohol",
+    "seoDescription": "",
+    "seoTitle": "",
+    "slug": "alcohol",
+  },
+  Object {
+    "__typename": "Category",
+    "id": "Q2F0ZWdvcnk6MjA=",
+    "name": "Paints",
+    "seoDescription": "",
+    "seoTitle": "",
+    "slug": "paints",
+  },
+  Object {
+    "__typename": "Category",
+    "id": "Q2F0ZWdvcnk6MjI=",
+    "name": "Homewares",
+    "seoDescription": "",
+    "seoTitle": "",
+    "slug": "homewares",
+  },
+]
+`;
+
+exports[`Categories object can get a list of subcategories 1`] = `
+Array [
+  Object {
+    "__typename": "Category",
+    "id": "Q2F0ZWdvcnk6MjA=",
+    "name": "Paints",
+    "seoDescription": "",
+    "seoTitle": "",
+    "slug": "paints",
+  },
+  Object {
+    "__typename": "Category",
+    "id": "Q2F0ZWdvcnk6MjI=",
+    "name": "Homewares",
+    "seoDescription": "",
+    "seoTitle": "",
+    "slug": "homewares",
+  },
+]
+`;
+
+exports[`Categories object can get new page 1`] = `
+Array [
+  Object {
+    "__typename": "Category",
+    "id": "Q2F0ZWdvcnk6Nw==",
+    "name": "Accessories",
+    "seoDescription": "",
+    "seoTitle": "",
+    "slug": "accessories",
+  },
+]
+`;
+
+exports[`Categories object can get new page 2`] = `
+Array [
+  Object {
+    "__typename": "Category",
+    "id": "Q2F0ZWdvcnk6Nw==",
+    "name": "Accessories",
+    "seoDescription": "",
+    "seoTitle": "",
+    "slug": "accessories",
+  },
+  Object {
+    "__typename": "Category",
+    "id": "Q2F0ZWdvcnk6OA==",
+    "name": "Groceries",
+    "seoDescription": "",
+    "seoTitle": "",
+    "slug": "groceries",
+  },
+]
+`;

--- a/src/api/categories/categories.test.ts
+++ b/src/api/categories/categories.test.ts
@@ -1,0 +1,71 @@
+import setupAPI from "../../../testUtils/api";
+import { CategoriesAPI } from "./categories";
+
+const { client } = setupAPI();
+
+describe("Categories object", () => {
+  const categoriesAPI = new CategoriesAPI(client);
+
+  it("can get a list of categories", async () => {
+    const list = categoriesAPI.getList({
+      first: 20,
+    });
+
+    expect(list.data).toBeUndefined();
+    expect(list.loading).toBe(true);
+    await list.current;
+
+    expect(list.data).toMatchSnapshot();
+    expect(list.loading).toBe(false);
+  });
+
+  it("can get new page", async () => {
+    const list = categoriesAPI.getList({
+      first: 1,
+    });
+
+    expect(list.data).toBeUndefined();
+    expect(list.loading).toBe(true);
+    await list.current;
+
+    expect(list.data).toMatchSnapshot();
+    expect(list.loading).toBe(false);
+
+    list.next();
+
+    expect(list.loading).toBe(true);
+
+    await list.current;
+
+    expect(list.data).toMatchSnapshot();
+    expect(list.loading).toBe(false);
+  });
+
+  it("can get a list of subcategories", async () => {
+    const list = categoriesAPI.getChildren({
+      first: 20,
+      id: "Q2F0ZWdvcnk6Nw==",
+    });
+
+    expect(list.data).toBeUndefined();
+    expect(list.loading).toBe(true);
+    await list.current;
+
+    expect(list.data).toMatchSnapshot();
+    expect(list.loading).toBe(false);
+  });
+
+  it("can get a list of ancestor categories", async () => {
+    const list = categoriesAPI.getAncestors({
+      first: 20,
+      id: "Q2F0ZWdvcnk6MjI=",
+    });
+
+    expect(list.data).toBeUndefined();
+    expect(list.loading).toBe(true);
+    await list.current;
+
+    expect(list.data).toMatchSnapshot();
+    expect(list.loading).toBe(false);
+  });
+});

--- a/src/api/categories/categories.test.ts
+++ b/src/api/categories/categories.test.ts
@@ -1,5 +1,6 @@
 import setupAPI from "../../../testUtils/api";
 import { CategoriesAPI } from "./categories";
+import * as fixtures from "./fixtures";
 
 const { client } = setupAPI();
 
@@ -44,7 +45,7 @@ describe("Categories object", () => {
   it("can get a list of subcategories", async () => {
     const list = categoriesAPI.getChildren({
       first: 20,
-      id: "Q2F0ZWdvcnk6Nw==",
+      id: fixtures.categoryWithChildren,
     });
 
     expect(list.data).toBeUndefined();
@@ -58,7 +59,7 @@ describe("Categories object", () => {
   it("can get a list of ancestor categories", async () => {
     const list = categoriesAPI.getAncestors({
       first: 20,
-      id: "Q2F0ZWdvcnk6MjI=",
+      id: fixtures.categoryWithParent,
     });
 
     expect(list.data).toBeUndefined();

--- a/src/api/categories/categories.ts
+++ b/src/api/categories/categories.ts
@@ -1,0 +1,53 @@
+import ApolloClient from "apollo-client";
+import { CategoryAncestorsListVariables } from "../../queries/gqlTypes/CategoryAncestorsList";
+import { CategoryChildrenListVariables } from "../../queries/gqlTypes/CategoryChildrenList";
+import {
+  CategoryList as CategoryListQuery,
+  CategoryListVariables,
+} from "../../queries/gqlTypes/CategoryList";
+import { BaseCategory } from "../../fragments/gqlTypes/BaseCategory";
+import { WithList } from "../types";
+import { CategoryList } from "./CategoryList";
+import { CategoryAncestorsList } from "./CategoryAncestorsList";
+import { CategoryChildrenList } from "./CategoryChildrenList";
+
+export class CategoriesAPI
+  implements WithList<CategoryListQuery, BaseCategory, CategoryListVariables> {
+  client: ApolloClient<any>;
+
+  constructor(client: ApolloClient<any>) {
+    this.client = client;
+  }
+
+  /**
+   * Method returning list of categories with ability to request next page
+   * @param params List parameters
+   */
+  getList = (variables: CategoryListVariables): CategoryList => {
+    const list = new CategoryList(this.client);
+
+    list.init(variables);
+
+    return list;
+  };
+
+  getAncestors = (
+    variables: CategoryAncestorsListVariables
+  ): CategoryAncestorsList => {
+    const list = new CategoryAncestorsList(this.client);
+
+    list.init(variables);
+
+    return list;
+  };
+
+  getChildren = (
+    variables: CategoryChildrenListVariables
+  ): CategoryChildrenList => {
+    const list = new CategoryChildrenList(this.client);
+
+    list.init(variables);
+
+    return list;
+  };
+}

--- a/src/api/categories/fixtures.ts
+++ b/src/api/categories/fixtures.ts
@@ -1,0 +1,2 @@
+export const categoryWithChildren = "Q2F0ZWdvcnk6Nw==";
+export const categoryWithParent = "Q2F0ZWdvcnk6MjI=";

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -12,6 +12,7 @@ import APIProxy from "./APIProxy";
 import { SaleorCartAPI } from "./Cart";
 import { SaleorCheckoutAPI } from "./Checkout";
 import { CollectionsAPI } from "./collections/collections";
+import { CategoriesAPI } from "./categories/categories";
 
 export * from "./Checkout";
 export * from "./Cart";
@@ -22,6 +23,8 @@ export class SaleorAPI {
   checkout: SaleorCheckoutAPI;
 
   cart: SaleorCartAPI;
+
+  categories: CategoriesAPI;
 
   collections: CollectionsAPI;
 
@@ -76,6 +79,7 @@ export class SaleorAPI {
       saleorState,
       jobsManager
     );
+    this.categories = new CategoriesAPI(client);
     this.collections = new CollectionsAPI(client);
 
     this.legacyAPIProxy.attachAuthListener(authenticated => {

--- a/src/fragments/categories.ts
+++ b/src/fragments/categories.ts
@@ -1,0 +1,24 @@
+import gql from "graphql-tag";
+
+export const baseCategoryFragment = gql`
+  fragment BaseCategory on Category {
+    id
+    name
+    slug
+    seoDescription
+    seoTitle
+  }
+`;
+
+export const categoryFragment = gql`
+  ${baseCategoryFragment}
+  fragment CategoryDetails on Category {
+    ...BaseCategory
+    backgroundImage {
+      alt
+      url
+    }
+    description
+    descriptionJson
+  }
+`;

--- a/src/fragments/gqlTypes/BaseCategory.ts
+++ b/src/fragments/gqlTypes/BaseCategory.ts
@@ -1,0 +1,20 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL fragment: BaseCategory
+// ====================================================
+
+export interface BaseCategory {
+  __typename: "Category";
+  /**
+   * The ID of the object.
+   */
+  id: string;
+  name: string;
+  slug: string;
+  seoDescription: string | null;
+  seoTitle: string | null;
+}

--- a/src/fragments/gqlTypes/CategoryDetails.ts
+++ b/src/fragments/gqlTypes/CategoryDetails.ts
@@ -1,0 +1,35 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL fragment: CategoryDetails
+// ====================================================
+
+export interface CategoryDetails_backgroundImage {
+  __typename: "Image";
+  /**
+   * Alt text for an image.
+   */
+  alt: string | null;
+  /**
+   * The URL of the image.
+   */
+  url: string;
+}
+
+export interface CategoryDetails {
+  __typename: "Category";
+  /**
+   * The ID of the object.
+   */
+  id: string;
+  name: string;
+  slug: string;
+  seoDescription: string | null;
+  seoTitle: string | null;
+  backgroundImage: CategoryDetails_backgroundImage | null;
+  description: string;
+  descriptionJson: any;
+}

--- a/src/queries/category.ts
+++ b/src/queries/category.ts
@@ -1,4 +1,63 @@
 import gql from "graphql-tag";
+import { pageInfo } from "../fragments/pageInfo";
+import { baseCategoryFragment } from "../fragments/categories";
+
+export const categoryList = gql`
+  ${baseCategoryFragment}
+  ${pageInfo}
+  query CategoryList($first: Int!, $after: String) {
+    categories(first: $first, after: $after) {
+      edges {
+        node {
+          ...BaseCategory
+        }
+      }
+      pageInfo {
+        ...PageInfo
+      }
+    }
+  }
+`;
+
+export const categoryChildrenList = gql`
+  ${baseCategoryFragment}
+  ${pageInfo}
+  query CategoryChildrenList($id: ID!, $first: Int!, $after: String) {
+    category(id: $id) {
+      id
+      children(first: $first, after: $after) {
+        edges {
+          node {
+            ...BaseCategory
+          }
+        }
+        pageInfo {
+          ...PageInfo
+        }
+      }
+    }
+  }
+`;
+
+export const categoryAncestorsList = gql`
+  ${baseCategoryFragment}
+  ${pageInfo}
+  query CategoryAncestorsList($id: ID!, $first: Int!, $after: String) {
+    category(id: $id) {
+      id
+      ancestors(first: $first, after: $after) {
+        edges {
+          node {
+            ...BaseCategory
+          }
+        }
+        pageInfo {
+          ...PageInfo
+        }
+      }
+    }
+  }
+`;
 
 export const categoryQuery = gql`
   query CategoryDetails($id: ID!) {

--- a/src/queries/gqlTypes/CategoryAncestorsList.ts
+++ b/src/queries/gqlTypes/CategoryAncestorsList.ts
@@ -1,0 +1,74 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL query operation: CategoryAncestorsList
+// ====================================================
+
+export interface CategoryAncestorsList_category_ancestors_edges_node {
+  __typename: "Category";
+  /**
+   * The ID of the object.
+   */
+  id: string;
+  name: string;
+  slug: string;
+  seoDescription: string | null;
+  seoTitle: string | null;
+}
+
+export interface CategoryAncestorsList_category_ancestors_edges {
+  __typename: "CategoryCountableEdge";
+  /**
+   * The item at the end of the edge.
+   */
+  node: CategoryAncestorsList_category_ancestors_edges_node;
+}
+
+export interface CategoryAncestorsList_category_ancestors_pageInfo {
+  __typename: "PageInfo";
+  /**
+   * When paginating forwards, the cursor to continue.
+   */
+  endCursor: string | null;
+  /**
+   * When paginating forwards, are there more items?
+   */
+  hasNextPage: boolean;
+}
+
+export interface CategoryAncestorsList_category_ancestors {
+  __typename: "CategoryCountableConnection";
+  edges: CategoryAncestorsList_category_ancestors_edges[];
+  /**
+   * Pagination data for this connection.
+   */
+  pageInfo: CategoryAncestorsList_category_ancestors_pageInfo;
+}
+
+export interface CategoryAncestorsList_category {
+  __typename: "Category";
+  /**
+   * The ID of the object.
+   */
+  id: string;
+  /**
+   * List of ancestors of the category.
+   */
+  ancestors: CategoryAncestorsList_category_ancestors | null;
+}
+
+export interface CategoryAncestorsList {
+  /**
+   * Look up a category by ID or slug.
+   */
+  category: CategoryAncestorsList_category | null;
+}
+
+export interface CategoryAncestorsListVariables {
+  id: string;
+  first: number;
+  after?: string | null;
+}

--- a/src/queries/gqlTypes/CategoryChildrenList.ts
+++ b/src/queries/gqlTypes/CategoryChildrenList.ts
@@ -1,0 +1,74 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL query operation: CategoryChildrenList
+// ====================================================
+
+export interface CategoryChildrenList_category_children_edges_node {
+  __typename: "Category";
+  /**
+   * The ID of the object.
+   */
+  id: string;
+  name: string;
+  slug: string;
+  seoDescription: string | null;
+  seoTitle: string | null;
+}
+
+export interface CategoryChildrenList_category_children_edges {
+  __typename: "CategoryCountableEdge";
+  /**
+   * The item at the end of the edge.
+   */
+  node: CategoryChildrenList_category_children_edges_node;
+}
+
+export interface CategoryChildrenList_category_children_pageInfo {
+  __typename: "PageInfo";
+  /**
+   * When paginating forwards, the cursor to continue.
+   */
+  endCursor: string | null;
+  /**
+   * When paginating forwards, are there more items?
+   */
+  hasNextPage: boolean;
+}
+
+export interface CategoryChildrenList_category_children {
+  __typename: "CategoryCountableConnection";
+  edges: CategoryChildrenList_category_children_edges[];
+  /**
+   * Pagination data for this connection.
+   */
+  pageInfo: CategoryChildrenList_category_children_pageInfo;
+}
+
+export interface CategoryChildrenList_category {
+  __typename: "Category";
+  /**
+   * The ID of the object.
+   */
+  id: string;
+  /**
+   * List of children of the category.
+   */
+  children: CategoryChildrenList_category_children | null;
+}
+
+export interface CategoryChildrenList {
+  /**
+   * Look up a category by ID or slug.
+   */
+  category: CategoryChildrenList_category | null;
+}
+
+export interface CategoryChildrenListVariables {
+  id: string;
+  first: number;
+  after?: string | null;
+}

--- a/src/queries/gqlTypes/CategoryList.ts
+++ b/src/queries/gqlTypes/CategoryList.ts
@@ -1,0 +1,61 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL query operation: CategoryList
+// ====================================================
+
+export interface CategoryList_categories_edges_node {
+  __typename: "Category";
+  /**
+   * The ID of the object.
+   */
+  id: string;
+  name: string;
+  slug: string;
+  seoDescription: string | null;
+  seoTitle: string | null;
+}
+
+export interface CategoryList_categories_edges {
+  __typename: "CategoryCountableEdge";
+  /**
+   * The item at the end of the edge.
+   */
+  node: CategoryList_categories_edges_node;
+}
+
+export interface CategoryList_categories_pageInfo {
+  __typename: "PageInfo";
+  /**
+   * When paginating forwards, the cursor to continue.
+   */
+  endCursor: string | null;
+  /**
+   * When paginating forwards, are there more items?
+   */
+  hasNextPage: boolean;
+}
+
+export interface CategoryList_categories {
+  __typename: "CategoryCountableConnection";
+  edges: CategoryList_categories_edges[];
+  /**
+   * Pagination data for this connection.
+   */
+  pageInfo: CategoryList_categories_pageInfo;
+}
+
+export interface CategoryList {
+  /**
+   * List of the shop's categories.
+   */
+  categories: CategoryList_categories | null;
+}
+
+export interface CategoryListVariables {
+  first: number;
+  after?: string | null;
+}

--- a/src/react/hooks/__snapshots__/categories.test.tsx.snap
+++ b/src/react/hooks/__snapshots__/categories.test.tsx.snap
@@ -1,0 +1,196 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`useCategoryAncestorsList can fetch category ancestors 1`] = `
+Array [
+  Object {
+    "__typename": "Category",
+    "id": "Q2F0ZWdvcnk6Nw==",
+    "name": "Accessories",
+    "seoDescription": "",
+    "seoTitle": "",
+    "slug": "accessories",
+  },
+]
+`;
+
+exports[`useCategoryChildrenList can fetch next page 1`] = `
+Array [
+  Object {
+    "__typename": "Category",
+    "id": "Q2F0ZWdvcnk6MjA=",
+    "name": "Paints",
+    "seoDescription": "",
+    "seoTitle": "",
+    "slug": "paints",
+  },
+]
+`;
+
+exports[`useCategoryChildrenList can fetch next page 2`] = `
+Array [
+  Object {
+    "__typename": "Category",
+    "id": "Q2F0ZWdvcnk6MjA=",
+    "name": "Paints",
+    "seoDescription": "",
+    "seoTitle": "",
+    "slug": "paints",
+  },
+  Object {
+    "__typename": "Category",
+    "id": "Q2F0ZWdvcnk6MjI=",
+    "name": "Homewares",
+    "seoDescription": "",
+    "seoTitle": "",
+    "slug": "homewares",
+  },
+]
+`;
+
+exports[`useCategoryChildrenList can fetch subcategories 1`] = `
+Array [
+  Object {
+    "__typename": "Category",
+    "id": "Q2F0ZWdvcnk6MjA=",
+    "name": "Paints",
+    "seoDescription": "",
+    "seoTitle": "",
+    "slug": "paints",
+  },
+  Object {
+    "__typename": "Category",
+    "id": "Q2F0ZWdvcnk6MjI=",
+    "name": "Homewares",
+    "seoDescription": "",
+    "seoTitle": "",
+    "slug": "homewares",
+  },
+]
+`;
+
+exports[`useCategoryList can fetch categories 1`] = `
+Array [
+  Object {
+    "__typename": "Category",
+    "id": "Q2F0ZWdvcnk6Nw==",
+    "name": "Accessories",
+    "seoDescription": "",
+    "seoTitle": "",
+    "slug": "accessories",
+  },
+  Object {
+    "__typename": "Category",
+    "id": "Q2F0ZWdvcnk6OA==",
+    "name": "Groceries",
+    "seoDescription": "",
+    "seoTitle": "",
+    "slug": "groceries",
+  },
+  Object {
+    "__typename": "Category",
+    "id": "Q2F0ZWdvcnk6OQ==",
+    "name": "Apparel",
+    "seoDescription": "",
+    "seoTitle": "",
+    "slug": "apparel",
+  },
+  Object {
+    "__typename": "Category",
+    "id": "Q2F0ZWdvcnk6MTA=",
+    "name": "T-shirts",
+    "seoDescription": "",
+    "seoTitle": "",
+    "slug": "t-shirts",
+  },
+  Object {
+    "__typename": "Category",
+    "id": "Q2F0ZWdvcnk6MTE=",
+    "name": "Polo Shirts",
+    "seoDescription": "",
+    "seoTitle": "",
+    "slug": "polo-shirts",
+  },
+  Object {
+    "__typename": "Category",
+    "id": "Q2F0ZWdvcnk6MTI=",
+    "name": "Hoodies",
+    "seoDescription": "",
+    "seoTitle": "",
+    "slug": "hoodies",
+  },
+  Object {
+    "__typename": "Category",
+    "id": "Q2F0ZWdvcnk6MTM=",
+    "name": "Footwear",
+    "seoDescription": "",
+    "seoTitle": "",
+    "slug": "footwear",
+  },
+  Object {
+    "__typename": "Category",
+    "id": "Q2F0ZWdvcnk6MTQ=",
+    "name": "Juices",
+    "seoDescription": "",
+    "seoTitle": "",
+    "slug": "juices",
+  },
+  Object {
+    "__typename": "Category",
+    "id": "Q2F0ZWdvcnk6MTU=",
+    "name": "Alcohol",
+    "seoDescription": "",
+    "seoTitle": "",
+    "slug": "alcohol",
+  },
+  Object {
+    "__typename": "Category",
+    "id": "Q2F0ZWdvcnk6MjA=",
+    "name": "Paints",
+    "seoDescription": "",
+    "seoTitle": "",
+    "slug": "paints",
+  },
+  Object {
+    "__typename": "Category",
+    "id": "Q2F0ZWdvcnk6MjI=",
+    "name": "Homewares",
+    "seoDescription": "",
+    "seoTitle": "",
+    "slug": "homewares",
+  },
+]
+`;
+
+exports[`useCategoryList can fetch next page 1`] = `
+Array [
+  Object {
+    "__typename": "Category",
+    "id": "Q2F0ZWdvcnk6Nw==",
+    "name": "Accessories",
+    "seoDescription": "",
+    "seoTitle": "",
+    "slug": "accessories",
+  },
+]
+`;
+
+exports[`useCategoryList can fetch next page 2`] = `
+Array [
+  Object {
+    "__typename": "Category",
+    "id": "Q2F0ZWdvcnk6Nw==",
+    "name": "Accessories",
+    "seoDescription": "",
+    "seoTitle": "",
+    "slug": "accessories",
+  },
+  Object {
+    "__typename": "Category",
+    "id": "Q2F0ZWdvcnk6OA==",
+    "name": "Groceries",
+    "seoDescription": "",
+    "seoTitle": "",
+    "slug": "groceries",
+  },
+]
+`;

--- a/src/react/hooks/categories.test.tsx
+++ b/src/react/hooks/categories.test.tsx
@@ -1,0 +1,140 @@
+import { act, renderHook } from "@testing-library/react-hooks";
+import React from "react";
+import { ApolloProvider } from "react-apollo";
+import setupAPI from "../../../testUtils/api";
+import {
+  useCategoryList,
+  useCategoryChildrenList,
+  useCategoryAncestorsList,
+} from "./categories";
+import * as fixtures from "../../api/categories/fixtures";
+
+const { client } = setupAPI();
+
+const wrapper: React.FC = ({ children }) => (
+  <ApolloProvider client={client}>{children}</ApolloProvider>
+);
+
+describe("useCategoryList", () => {
+  it("can fetch categories", async () => {
+    const { result } = renderHook(
+      () =>
+        useCategoryList({
+          first: 20,
+        }),
+      {
+        wrapper,
+      }
+    );
+
+    expect(result.current.data).toBe(undefined);
+    expect(result.current.loading).toBe(true);
+
+    // @ts-ignore
+    await act(() => result.current.current);
+
+    expect(result.current.data).toMatchSnapshot();
+    expect(result.current.loading).toBe(false);
+  });
+
+  it("can fetch next page", async () => {
+    const { result } = renderHook(
+      () =>
+        useCategoryList({
+          first: 1,
+        }),
+      {
+        wrapper,
+      }
+    );
+
+    expect(result.current.data).toBe(undefined);
+    expect(result.current.loading).toBe(true);
+
+    // @ts-ignore
+    await act(() => result.current.current);
+
+    expect(result.current.data).toMatchSnapshot();
+    expect(result.current.loading).toBe(false);
+
+    await act(result.current.next);
+
+    expect(result.current.data).toMatchSnapshot();
+    expect(result.current.loading).toBe(false);
+  });
+});
+
+describe("useCategoryAncestorsList", () => {
+  it("can fetch category ancestors", async () => {
+    const { result } = renderHook(
+      () =>
+        useCategoryAncestorsList({
+          first: 20,
+          id: fixtures.categoryWithParent,
+        }),
+      {
+        wrapper,
+      }
+    );
+
+    expect(result.current.data).toBe(undefined);
+    expect(result.current.loading).toBe(true);
+
+    // @ts-ignore
+    await act(() => result.current.current);
+
+    expect(result.current.data).toMatchSnapshot();
+    expect(result.current.loading).toBe(false);
+  });
+});
+
+describe("useCategoryChildrenList", () => {
+  it("can fetch subcategories", async () => {
+    const { result } = renderHook(
+      () =>
+        useCategoryChildrenList({
+          first: 20,
+          id: fixtures.categoryWithChildren,
+        }),
+      {
+        wrapper,
+      }
+    );
+
+    expect(result.current.data).toBe(undefined);
+    expect(result.current.loading).toBe(true);
+
+    // @ts-ignore
+    await act(() => result.current.current);
+
+    expect(result.current.data).toMatchSnapshot();
+    expect(result.current.loading).toBe(false);
+  });
+
+  it("can fetch next page", async () => {
+    const { result } = renderHook(
+      () =>
+        useCategoryChildrenList({
+          first: 1,
+          id: fixtures.categoryWithChildren,
+        }),
+      {
+        wrapper,
+      }
+    );
+
+    expect(result.current.data).toBe(undefined);
+    expect(result.current.loading).toBe(true);
+
+    // @ts-ignore
+    await act(() => result.current.current);
+
+    expect(result.current.data).toMatchSnapshot();
+    expect(result.current.loading).toBe(false);
+
+    await act(result.current.next);
+
+    expect(result.current.data).toMatchSnapshot();
+    expect(result.current.loading).toBe(false);
+  });
+});

--- a/src/react/hooks/categories.ts
+++ b/src/react/hooks/categories.ts
@@ -1,0 +1,12 @@
+import { CategoryAncestorsList } from "../../api/categories/CategoryAncestorsList";
+import { CategoryChildrenList } from "../../api/categories/CategoryChildrenList";
+import { CategoryList } from "../../api/categories/CategoryList";
+import { makeList } from "./utils";
+
+export const useCategoryList = makeList(client => new CategoryList(client));
+export const useCategoryAncestorsList = makeList(
+  client => new CategoryAncestorsList(client)
+);
+export const useCategoryChildrenList = makeList(
+  client => new CategoryChildrenList(client)
+);

--- a/src/react/index.ts
+++ b/src/react/index.ts
@@ -3,4 +3,5 @@ export * from "./queries";
 export * from "./mutations";
 export * from "./hooks";
 export * from "./helpers";
+export * from "./hooks/categories";
 export * from "./hooks/collections";


### PR DESCRIPTION
I want to merge this because it allows fetching category list, as well as subcategories and category ancestors. Also adds react hooks for this.

Usage:
```
SaleorAPI.categories.getList({
  // variables
})
```

and for React:
```
const categories = useCategoryList({
  // variables
})
```

Note: build on top of #15 