### PR TITLE
Fix useQuery wrong loading state

### DIFF
--- a/src/api/APIProxy.ts
+++ b/src/api/APIProxy.ts
@@ -214,7 +214,10 @@ class APIProxy {
         skip?: boolean;
         onComplete?: () => void;
         onError?: (error: ApolloError) => void;
-        onUpdate: (data: ReturnType<typeof mapFn> | null) => void;
+        onUpdate: (
+          data: ReturnType<typeof mapFn> | null,
+          loading?: boolean
+        ) => void;
       }
     ) => {
       const { onComplete, onError, onUpdate, ...apolloClientOptions } = options;
@@ -240,7 +243,7 @@ class APIProxy {
 
       const subscription = observable.subscribe(
         result => {
-          const { data, errors: apolloErrors } = result;
+          const { data, errors: apolloErrors, loading } = result;
           const errorHandledData = handleDataErrors(
             mapFn,
             data as any,
@@ -252,7 +255,7 @@ class APIProxy {
                 onError(errorHandledData.errors);
               }
             } else {
-              onUpdate(errorHandledData.data as TResult);
+              onUpdate(errorHandledData.data as TResult, loading);
               if (onComplete) {
                 onComplete();
               }

--- a/src/react/useQuery.ts
+++ b/src/react/useQuery.ts
@@ -44,12 +44,12 @@ const useQuery = <
     loading: true,
   });
 
-  const setData = React.useCallback((data: TData) => {
+  const setData = React.useCallback((data: TData, loading?: boolean) => {
     if (!isEqual(data, prevDataRef.current)) {
       prevDataRef.current = data;
       setResult({ data, error: null, loading: false });
     } else {
-      setResult(previousResult => ({ ...previousResult, loading: false }));
+      setResult(previousResult => ({ ...previousResult, loading: !!loading }));
     }
   }, []);
 
@@ -68,8 +68,8 @@ const useQuery = <
             error,
             loading: false,
           })),
-        onUpdate: (data: TData) => {
-          setData(data);
+        onUpdate: (data: TData, loading?: boolean) => {
+          setData(data, loading);
         },
       }),
     [query, options.skip, authenticated]


### PR DESCRIPTION
It fixes improperly setting loading state to false for hooks which uses useQuery function while Apollo still had a loading state active. Because of this, it fixes `useOrderDetails()` hook loading state.

It consequently fixes the blinking 404 page when going to the order details page.

From the debugger:
before:
<img width="833" alt="Zrzut ekranu 2020-09-7 o 17 32 06" src="https://user-images.githubusercontent.com/9825562/92405013-0654c180-f135-11ea-9a3a-cbeaf484a4bf.png">
after:
<img width="821" alt="Zrzut ekranu 2020-09-7 o 18 09 22" src="https://user-images.githubusercontent.com/9825562/92405144-4a47c680-f135-11ea-8b77-97d072a094d5.png">
