### PR TITLE
Fix Firefox auth

### DIFF
--- a/src/api/Auth/index.ts
+++ b/src/api/Auth/index.ts
@@ -60,7 +60,7 @@ export class AuthAPI extends ErrorListener {
 
     this.loaded = false;
     this.tokenRefreshing = false;
-    this.tokenVerifying = true;
+    this.tokenVerifying = !!this.saleorState.signInToken;
 
     this.saleorState.subscribeToChange(StateItems.USER, (user: User | null) => {
       this.user = user;
@@ -94,7 +94,6 @@ export class AuthAPI extends ErrorListener {
     );
 
     if (!this.saleorState.signInToken && window.PasswordCredential) {
-      this.tokenVerifying = false;
       this.autoSignIn();
     }
   }

--- a/src/state/index.ts
+++ b/src/state/index.ts
@@ -182,7 +182,7 @@ export class SaleorState extends NamedObservable<StateItems> {
     });
   };
 
-  private onSignInTokenVerifyingUpdate = async (tokenVerifying: boolean) => {
+  private onSignInTokenVerifyingUpdate = (tokenVerifying: boolean) => {
     this.signInTokenVerifying = tokenVerifying;
     this.notifyChange(
       StateItems.SIGN_IN_TOKEN_VERIFYING,


### PR DESCRIPTION
It fixes token verification state when `window.PasswordCredential` is not available in the browser like Firefox.