### PR TITLE
Don't synthesize DOM events at module import time

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -22,8 +22,6 @@ export function isJwtError(error: GraphQLError): boolean {
   return jwtError;
 }
 
-export const authEvent = new Event("auth");
-
 export function getAuthToken(): string | null {
   try {
     return localStorage.getItem("token");
@@ -34,6 +32,7 @@ export function getAuthToken(): string | null {
 
 export function setAuthToken(token: string) {
   localStorage.setItem("token", token);
+  const authEvent = new Event("auth");
   dispatchEvent(authEvent);
 }
 


### PR DESCRIPTION
This makes it possible to import the SDK in non-browser platforms like next.js