### PR TITLE
Extend Auth API with account register and password reset mutations.

### DIFF
--- a/src/api/Auth/index.ts
+++ b/src/api/Auth/index.ts
@@ -99,6 +99,45 @@ export class AuthAPI extends ErrorListener {
   }
 
   /**
+   * Tries to register a user account with given email and password.
+   * @param email Email used for new account.
+   * @param password Password used for new account.
+   * @param redirectUrl URL used for redirection.
+   */
+  registerAccount = async (
+    email: string,
+    password: string,
+    redirectUrl: string
+  ): PromiseRunResponse<DataErrorAuthTypes> => {
+    const { data, dataError } = await this.jobsManager.run(
+      "auth",
+      "registerAccount",
+      {
+        email,
+        password,
+        redirectUrl,
+      }
+    );
+
+    if (dataError?.error) {
+      this.fireError(dataError.error, DataErrorAuthTypes.REGISTER_ACCOUNT);
+    }
+
+    if (dataError) {
+      return {
+        data,
+        dataError,
+        pending: false,
+      };
+    }
+
+    return {
+      data,
+      pending: false,
+    };
+  };
+
+  /**
    * Tries to authenticate user with given email and password.
    * @param email Email used for authentication.
    * @param password Password used for authentication.

--- a/src/api/Auth/index.ts
+++ b/src/api/Auth/index.ts
@@ -138,6 +138,42 @@ export class AuthAPI extends ErrorListener {
   };
 
   /**
+   * Requests a password reset for an user account with given email.
+   * @param email Email used for account.
+   * @param redirectUrl URL used for redirection.
+   */
+  resetPasswordRequest = async (
+    email: string,
+    redirectUrl: string
+  ): PromiseRunResponse<DataErrorAuthTypes> => {
+    const { data, dataError } = await this.jobsManager.run(
+      "auth",
+      "resetPasswordRequest",
+      {
+        email,
+        redirectUrl,
+      }
+    );
+
+    if (dataError?.error) {
+      this.fireError(dataError.error, DataErrorAuthTypes.RESET_PASSWORD_REQUEST);
+    }
+
+    if (dataError) {
+      return {
+        data,
+        dataError,
+        pending: false,
+      };
+    }
+
+    return {
+      data,
+      pending: false,
+    };
+  };
+
+  /**
    * Tries to authenticate user with given email and password.
    * @param email Email used for authentication.
    * @param password Password used for authentication.

--- a/src/api/Auth/types.ts
+++ b/src/api/Auth/types.ts
@@ -3,4 +3,5 @@ export enum DataErrorAuthTypes {
   "REFRESH_TOKEN",
   "VERIFY_TOKEN",
   "GET_USER",
+  "REGISTER_ACCOUNT",
 }

--- a/src/api/Auth/types.ts
+++ b/src/api/Auth/types.ts
@@ -4,4 +4,5 @@ export enum DataErrorAuthTypes {
   "VERIFY_TOKEN",
   "GET_USER",
   "REGISTER_ACCOUNT",
+  "RESET_PASSWORD_REQUEST",
 }

--- a/src/data/ApolloClientManager/index.ts
+++ b/src/data/ApolloClientManager/index.ts
@@ -11,6 +11,7 @@ import {
   IPaymentModel,
 } from "../../helpers/LocalStorageHandler";
 import * as AuthMutations from "../../mutations/auth";
+import * as UserMutations from "../../mutations/user";
 import * as CheckoutMutations from "../../mutations/checkout";
 import {
   AddCheckoutPromoCode,
@@ -32,6 +33,10 @@ import {
   RemoveCheckoutPromoCode,
   RemoveCheckoutPromoCodeVariables,
 } from "../../mutations/gqlTypes/RemoveCheckoutPromoCode";
+import {
+  RegisterAccount,
+  RegisterAccountVariables,
+} from "../../mutations/gqlTypes/RegisterAccount";
 import {
   TokenAuth,
   TokenAuthVariables,
@@ -114,6 +119,41 @@ export class ApolloClientManager {
     }
     return {
       data: data?.me,
+    };
+  };
+
+  registerAccount = async (
+    email: string,
+    password: string,
+    redirectUrl: string
+  ) => {
+    const { data, errors } = await this.client.mutate<
+      RegisterAccount,
+      RegisterAccountVariables
+    >({
+      fetchPolicy: "no-cache",
+      mutation: UserMutations.registerAccount,
+      variables: {
+        email,
+        password,
+        redirectUrl,
+      },
+    });
+
+    if (errors?.length) {
+      return {
+        error: errors,
+      };
+    }
+    if (data?.accountRegister?.accountErrors.length) {
+      return {
+        error: data.accountRegister.accountErrors,
+      };
+    }
+    return {
+      data: {
+        requiresConfirmation: data?.accountRegister?.requiresConfirmation,
+      },
     };
   };
 

--- a/src/data/ApolloClientManager/index.ts
+++ b/src/data/ApolloClientManager/index.ts
@@ -38,6 +38,10 @@ import {
   RegisterAccountVariables,
 } from "../../mutations/gqlTypes/RegisterAccount";
 import {
+  ResetPasswordRequest,
+  ResetPasswordRequestVariables,
+} from "../../mutations/gqlTypes/ResetPasswordRequest";
+import {
   TokenAuth,
   TokenAuthVariables,
 } from "../../mutations/gqlTypes/TokenAuth";
@@ -155,6 +159,35 @@ export class ApolloClientManager {
         requiresConfirmation: data?.accountRegister?.requiresConfirmation,
       },
     };
+  };
+
+  resetPasswordRequest = async (
+    email: string,
+    redirectUrl: string
+  ) => {
+    const { data, errors } = await this.client.mutate<
+      ResetPasswordRequest,
+      ResetPasswordRequestVariables
+    >({
+      fetchPolicy: "no-cache",
+      mutation: UserMutations.resetPasswordRequest,
+      variables: {
+        email,
+        redirectUrl,
+      },
+    });
+
+    if (errors?.length) {
+      return {
+        error: errors,
+      };
+    }
+    if (data?.requestPasswordReset?.accountErrors.length) {
+      return {
+        error: data.requestPasswordReset.accountErrors,
+      };
+    }
+    return {};
   };
 
   signIn = async (email: string, password: string) => {

--- a/src/jobs/Auth/AuthJobs.ts
+++ b/src/jobs/Auth/AuthJobs.ts
@@ -48,6 +48,35 @@ export class AuthJobs extends JobsHandler<AuthJobsEventsValues> {
     };
   };
 
+  registerAccount = async ({
+    email,
+    password,
+    redirectUrl,
+  }: {
+    email: string;
+    password: string;
+    redirectUrl: string;
+  }): PromiseAuthJobRunResponse => {
+    const { data, error } = await this.apolloClientManager.registerAccount(
+      email,
+      password,
+      redirectUrl
+    );
+
+    if (error) {
+      return {
+        dataError: {
+          error,
+          type: DataErrorAuthTypes.REGISTER_ACCOUNT,
+        },
+      };
+    }
+
+    return {
+      data,
+    };
+  };
+
   signIn = async ({
     email,
     password,

--- a/src/jobs/Auth/AuthJobs.ts
+++ b/src/jobs/Auth/AuthJobs.ts
@@ -77,6 +77,30 @@ export class AuthJobs extends JobsHandler<AuthJobsEventsValues> {
     };
   };
 
+  resetPasswordRequest = async ({
+    email,
+    redirectUrl,
+  }: {
+    email: string;
+    redirectUrl: string;
+  }): PromiseAuthJobRunResponse => {
+    const { error } = await this.apolloClientManager.resetPasswordRequest(
+      email,
+      redirectUrl
+    );
+
+    if (error) {
+      return {
+        dataError: {
+          error,
+          type: DataErrorAuthTypes.RESET_PASSWORD_REQUEST,
+        },
+      };
+    }
+
+    return {};
+  };
+
   signIn = async ({
     email,
     password,

--- a/src/mutations/gqlTypes/RegisterAccount.ts
+++ b/src/mutations/gqlTypes/RegisterAccount.ts
@@ -1,0 +1,49 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+import { AccountErrorCode } from "./../../gqlTypes/globalTypes";
+
+// ====================================================
+// GraphQL mutation operation: RegisterAccount
+// ====================================================
+
+export interface RegisterAccount_accountRegister_accountErrors {
+  __typename: "AccountError";
+  /**
+   * Name of a field that caused the error. A value of `null` indicates that the
+   * error isn't associated with a particular field.
+   */
+  field: string | null;
+  /**
+   * The error message.
+   */
+  message: string | null;
+  /**
+   * The error code.
+   */
+  code: AccountErrorCode;
+}
+
+export interface RegisterAccount_accountRegister {
+  __typename: "AccountRegister";
+  accountErrors: RegisterAccount_accountRegister_accountErrors[];
+  /**
+   * Informs whether users need to confirm their email address.
+   */
+  requiresConfirmation: boolean | null;
+}
+
+export interface RegisterAccount {
+  /**
+   * Register a new user.
+   */
+  accountRegister: RegisterAccount_accountRegister | null;
+}
+
+export interface RegisterAccountVariables {
+  email: string;
+  password: string;
+  redirectUrl: string;
+}

--- a/src/mutations/gqlTypes/ResetPasswordRequest.ts
+++ b/src/mutations/gqlTypes/ResetPasswordRequest.ts
@@ -1,0 +1,44 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+import { AccountErrorCode } from "./../../gqlTypes/globalTypes";
+
+// ====================================================
+// GraphQL mutation operation: ResetPasswordRequest
+// ====================================================
+
+export interface ResetPasswordRequest_requestPasswordReset_accountErrors {
+  __typename: "AccountError";
+  /**
+   * Name of a field that caused the error. A value of `null` indicates that the
+   * error isn't associated with a particular field.
+   */
+  field: string | null;
+  /**
+   * The error message.
+   */
+  message: string | null;
+  /**
+   * The error code.
+   */
+  code: AccountErrorCode;
+}
+
+export interface ResetPasswordRequest_requestPasswordReset {
+  __typename: "RequestPasswordReset";
+  accountErrors: ResetPasswordRequest_requestPasswordReset_accountErrors[];
+}
+
+export interface ResetPasswordRequest {
+  /**
+   * Sends an email with the account password modification link.
+   */
+  requestPasswordReset: ResetPasswordRequest_requestPasswordReset | null;
+}
+
+export interface ResetPasswordRequestVariables {
+  email: string;
+  redirectUrl: string;
+}

--- a/src/mutations/user.ts
+++ b/src/mutations/user.ts
@@ -14,6 +14,21 @@ export const changeUserPassword = gql`
   }
 `;
 
+export const registerAccount = gql`
+  mutation RegisterAccount($email: String!, $password: String!, $redirectUrl: String!) {
+    accountRegister(
+      input: { email: $email, password: $password, redirectUrl: $redirectUrl }
+    ) {
+      accountErrors {
+        field
+        message
+        code
+      }
+      requiresConfirmation
+    }
+  }
+`;
+
 export const accountUpdate = gql`
   ${userFragment}
   ${accountErrorFragment}

--- a/src/mutations/user.ts
+++ b/src/mutations/user.ts
@@ -29,6 +29,18 @@ export const registerAccount = gql`
   }
 `;
 
+export const resetPasswordRequest = gql`
+  mutation ResetPasswordRequest($email: String!, $redirectUrl: String!) {
+    requestPasswordReset(email: $email, redirectUrl: $redirectUrl) {
+      accountErrors {
+        field
+        message
+        code
+      }
+    }
+  }
+`;
+
 export const accountUpdate = gql`
   ${userFragment}
   ${accountErrorFragment}


### PR DESCRIPTION
I left some commented `fireError` calls as I was unsure if I they are needed.

This is my first time working with Saleor, so some guidance would be appreciated.

I will update the PR once I get some feedback.