### PR TITLE
Drop billing addres from payment input

### DIFF
--- a/src/api/Checkout/index.ts
+++ b/src/api/Checkout/index.ts
@@ -409,22 +409,15 @@ export class SaleorCheckoutAPI extends ErrorListener {
 
   createPayment = async (input: CreatePaymentInput): CheckoutResponse => {
     const checkoutId = this.saleorState.checkout?.id;
-    const billingAddress = this.saleorState.checkout?.billingAddress;
     const amount = this.saleorState.summaryPrices?.totalPrice?.gross.amount;
 
-    if (
-      checkoutId &&
-      billingAddress &&
-      amount !== null &&
-      amount !== undefined
-    ) {
+    if (checkoutId && amount !== null && amount !== undefined) {
       const { data, dataError } = await this.jobsManager.run(
         "checkout",
         "createPayment",
         {
           ...input,
           amount,
-          billingAddress,
           checkoutId,
         }
       );

--- a/src/data/ApolloClientManager/index.ts
+++ b/src/data/ApolloClientManager/index.ts
@@ -890,7 +890,6 @@ export class ApolloClientManager {
     amount,
     checkoutId,
     gateway,
-    billingAddress,
     token,
     returnUrl,
   }: CreatePaymentInput) => {
@@ -899,21 +898,6 @@ export class ApolloClientManager {
         checkoutId,
         paymentInput: {
           amount,
-          billingAddress: {
-            city: billingAddress.city,
-            companyName: billingAddress.companyName,
-            country:
-              CountryCode[
-                billingAddress?.country?.code as keyof typeof CountryCode
-              ],
-            countryArea: billingAddress.countryArea,
-            firstName: billingAddress.firstName,
-            lastName: billingAddress.lastName,
-            phone: billingAddress.phone,
-            postalCode: billingAddress.postalCode,
-            streetAddress1: billingAddress.streetAddress1,
-            streetAddress2: billingAddress.streetAddress2,
-          },
           gateway,
           returnUrl,
           token,

--- a/src/data/ApolloClientManager/types.ts
+++ b/src/data/ApolloClientManager/types.ts
@@ -1,7 +1,5 @@
 import { ApolloError } from "apollo-client";
 
-import { ICheckoutAddress } from "../../helpers/LocalStorageHandler";
-
 export enum PendingSaveItems {
   UPDATE_CART = "updateCart",
   BILLING_ADDRESS = "billingAddress",
@@ -33,7 +31,6 @@ export interface CreatePaymentInput {
   amount: number;
   checkoutId: string;
   gateway: string;
-  billingAddress: ICheckoutAddress;
   token?: string;
   returnUrl?: string;
 }

--- a/src/gqlTypes/globalTypes.ts
+++ b/src/gqlTypes/globalTypes.ts
@@ -487,7 +487,6 @@ export interface PaymentInput {
   gateway: string;
   token?: string | null;
   amount?: any | null;
-  billingAddress?: AddressInput | null;
   returnUrl?: string | null;
 }
 

--- a/src/jobs/Checkout/CheckoutJobs.ts
+++ b/src/jobs/Checkout/CheckoutJobs.ts
@@ -296,7 +296,6 @@ class CheckoutJobs extends JobsHandler<{}> {
     amount,
     gateway,
     token,
-    billingAddress,
     creditCard,
     returnUrl,
   }: CreatePaymentJobInput): PromiseCheckoutJobRunResponse => {
@@ -304,7 +303,6 @@ class CheckoutJobs extends JobsHandler<{}> {
 
     const { data, error } = await this.apolloClientManager.createPayment({
       amount,
-      billingAddress,
       checkoutId,
       gateway,
       returnUrl,

--- a/src/jobs/Checkout/types.ts
+++ b/src/jobs/Checkout/types.ts
@@ -58,7 +58,6 @@ export interface CreatePaymentJobInput {
   amount: number;
   gateway: string;
   token?: string;
-  billingAddress: ICheckoutAddress;
   creditCard?: ICreditCard;
   returnUrl?: string;
 }


### PR DESCRIPTION
`billingAddress` in `checkoutPaymentCreate` mutation is deprecated and this PR removes this field from the API call. The backend uses now a billing address which is assigned to the checkout instance. If there is no billing address assigned, a validation error would be returned. 