### PR TITLE
Drop geolocalization query

### DIFF
--- a/src/gqlTypes/globalTypes.ts
+++ b/src/gqlTypes/globalTypes.ts
@@ -416,6 +416,7 @@ export enum ProductOrderField {
   PRICE = "PRICE",
   PUBLICATION_DATE = "PUBLICATION_DATE",
   PUBLISHED = "PUBLISHED",
+  RANK = "RANK",
   RATING = "RATING",
   TYPE = "TYPE",
 }

--- a/src/queries/gqlTypes/GetShop.ts
+++ b/src/queries/gqlTypes/GetShop.ts
@@ -31,26 +31,6 @@ export interface GetShop_shop_countries {
   code: string;
 }
 
-export interface GetShop_shop_geolocalization_country {
-  __typename: "CountryDisplay";
-  /**
-   * Country code.
-   */
-  code: string;
-  /**
-   * Country name.
-   */
-  country: string;
-}
-
-export interface GetShop_shop_geolocalization {
-  __typename: "Geolocalization";
-  /**
-   * Country of the user acquired by his IP address.
-   */
-  country: GetShop_shop_geolocalization_country | null;
-}
-
 export interface GetShop_shop {
   __typename: "Shop";
   /**
@@ -65,10 +45,6 @@ export interface GetShop_shop {
    * List of countries available in the shop.
    */
   countries: GetShop_shop_countries[];
-  /**
-   * Customer's geolocalization data.
-   */
-  geolocalization: GetShop_shop_geolocalization | null;
 }
 
 export interface GetShop {

--- a/src/queries/shop.ts
+++ b/src/queries/shop.ts
@@ -12,12 +12,6 @@ export const getShop = gql`
         country
         code
       }
-      geolocalization {
-        country {
-          code
-          country
-        }
-      }
     }
   }
 `;


### PR DESCRIPTION
The `geolocalization` query will be dropped in Saleor 3.0, this PR removes the field from SDK.