### PR TITLE
fix 0 quantity issue

### DIFF
--- a/src/jobs/Checkout/CheckoutJobs.ts
+++ b/src/jobs/Checkout/CheckoutJobs.ts
@@ -73,9 +73,12 @@ class CheckoutJobs extends JobsHandler<{}> {
     billingAddress,
     selectedBillingAddressId,
   }: CreateCheckoutJobInput): PromiseCheckoutJobRunResponse => {
+
+    const cleanedLines = lines.filter(line => line.quantity !== 0);
+
     const { data, error } = await this.apolloClientManager.createCheckout(
       email,
-      lines,
+      cleanedLines,
       channel,
       shippingAddress,
       billingAddress


### PR DESCRIPTION
Simple fix yet it fixes a serious problem. With the current version, the moment when the user decides to delete an item, from that point forward the user will never be able to buy a product again. (As long as he is recognized).

Because Saleor is unable to process 0 quantity products yet this plugin adds the 0 when removing the item.
Thus even if you remove the 0 quantity, those products will appear again and block the whole checkout process.

The demo app as well is broken, just remove an item and try to buy another one, you won't get pass the create checkout process.
