### PR TITLE
Fix checkout issues with 0 quantity

### DIFF
--- a/src/data/LocalStorageManager/index.ts
+++ b/src/data/LocalStorageManager/index.ts
@@ -59,7 +59,7 @@ export class LocalStorageManager {
     const alteredLines = lines.filter(
       variant => variant.variant.id !== variantId
     );
-    if (variantInCheckout) {
+    if (variantInCheckout && this.saleorState.checkout) {
       variantInCheckout.quantity = 0;
       alteredLines.push(variantInCheckout);
     }

--- a/src/jobs/Checkout/CheckoutJobs.ts
+++ b/src/jobs/Checkout/CheckoutJobs.ts
@@ -73,9 +73,10 @@ class CheckoutJobs extends JobsHandler<{}> {
     billingAddress,
     selectedBillingAddressId,
   }: CreateCheckoutJobInput): PromiseCheckoutJobRunResponse => {
+    const cleanedLines = lines.filter(line => line.quantity !== 0);
     const { data, error } = await this.apolloClientManager.createCheckout(
       email,
-      lines,
+      cleanedLines,
       channel,
       shippingAddress,
       billingAddress


### PR DESCRIPTION
Credits to #109 by @gorjan-mishevski for finding the root cause. Apart from cleaning the lines itself, for checkouts that do not yet exist the line is filtered out before saved to storage.